### PR TITLE
Implement WebSocket transport and integrate with native types

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
-/node_modules
+node_modules
 notes.txt
+dist

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,10 +9,18 @@
       "version": "0.0.1",
       "license": "MIT",
       "devDependencies": {
+        "@cloudflare/workers-types": "^4.20250805.0",
         "tsup": "^8.4.0",
         "typescript": "^5.8.2",
         "vitest": "^3.0.8"
       }
+    },
+    "node_modules/@cloudflare/workers-types": {
+      "version": "4.20250805.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-4.20250805.0.tgz",
+      "integrity": "sha512-HOt0lqFiw5WzhvxH/IViMAWI/zwzokCSx33DlRnJqECT9khskK9X4Jrw/+IiAprJ5YloiFxK8Xn1oGbsabdUWg==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0"
     },
     "node_modules/@esbuild/aix-ppc64": {
       "version": "0.25.5",

--- a/package.json
+++ b/package.json
@@ -14,13 +14,14 @@
     "access": "public"
   },
   "scripts": {
-    "build": "tsup",
-    "build:watch": "tsup --watch",
+    "build": "tsup src/index.ts --format esm --external \"cloudflare:workers\"",
+    "build:watch": "tsup src/index.ts --format esm --external \"cloudflare:workers\" --watch",
     "test": "vitest run",
     "test:watch": "vitest",
     "prepublishOnly": "npm run build"
   },
   "devDependencies": {
+    "@cloudflare/workers-types": "^4.20250805.0",
     "tsup": "^8.4.0",
     "typescript": "^5.8.2",
     "vitest": "^3.0.8"

--- a/src/client.ts
+++ b/src/client.ts
@@ -1,0 +1,45 @@
+import { RpcSession, RpcStub } from "./index.js";
+import type { Serializable } from "./types.js";
+import { WebSocketTransport } from "./worker.js";
+
+export interface RpcWebSocketSession<T extends Serializable<T> = undefined> {
+  getStub(): RpcStub<T>;
+  getStats(): { imports: number; exports: number };
+  close(): void;
+}
+
+class RpcWebSocketSessionImpl<T extends Serializable<T>>
+  implements RpcWebSocketSession<T>
+{
+  private session: RpcSession<T>;
+  private transport: WebSocketTransport;
+
+  constructor(session: RpcSession<T>, transport: WebSocketTransport) {
+    this.session = session;
+    this.transport = transport;
+  }
+
+  getStub(): RpcStub<T> {
+    return this.session.getRemoteMain();
+  }
+
+  getStats(): { imports: number; exports: number } {
+    return this.session.getStats();
+  }
+
+  close(): void {
+    this.transport.abort(new Error("Session closed by client"));
+  }
+}
+
+// Main WebSocket client function
+export function rpcOverWebSocket<T extends Serializable<T> = undefined>(
+  url: string,
+  localMain?: any
+): RpcWebSocketSession<T> {
+  const transport = new WebSocketTransport(new WebSocket(url));
+  const session = new RpcSession<T>(transport, localMain);
+
+  // @ts-ignore nested types
+  return new RpcWebSocketSessionImpl(session, transport);
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -26,3 +26,6 @@ export const RpcSession: {
   new <T extends Serializable<T> = undefined>(
       transport: RpcTransport, localMain?: any): RpcSession<T>;
 } = <any>RpcSessionImpl;
+
+export { receiveRpcOverHttp } from "./worker.js";
+export { rpcOverWebSocket } from "./client.js";

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -1,0 +1,142 @@
+import { RpcTransport } from "./rpc.js";
+import { RpcSession } from "./index.js";
+import { RpcTarget } from "./core.js";
+
+// WebSocket transport for Cloudflare Workers
+export class WebSocketTransport implements RpcTransport {
+  private pendingMessages: string[] = [];
+
+  private pendingReceiveRequests: Omit<
+    ReturnType<typeof Promise.withResolvers<string>>,
+    "promise"
+  >[] = [];
+
+  private aborted = false;
+  private abortReason?: any;
+  private ws: WebSocket;
+
+  private setup() {
+    // Set up WebSocket event handlers
+    this.ws.addEventListener("message", (event) => {
+      const message = event.data as string;
+      console.log("receive", message);
+
+      const request = this.pendingReceiveRequests.shift();
+      if (request) {
+        request.resolve(message);
+      } else {
+        this.pendingMessages.push(message);
+      }
+    });
+
+    this.ws.addEventListener("close", (event) => {
+      const error = new Error(
+        `WebSocket closed: ${event.code} ${event.reason}`
+      );
+      this.handleError(error);
+    });
+
+    this.ws.addEventListener("error", () => {
+      const error = new Error("WebSocket error occurred");
+      this.handleError(error);
+    });
+  }
+
+  constructor(websocket: WebSocket) {
+    this.ws = websocket;
+    this.setup();
+  }
+
+  private handleError(error: any) {
+    if (this.aborted) return;
+
+    this.aborted = true;
+    this.abortReason = error;
+
+    for (const { reject } of this.pendingReceiveRequests) {
+      reject(error);
+    }
+
+    this.pendingReceiveRequests = [];
+  }
+
+  async send(message: string): Promise<void> {
+    console.log("send", message);
+    if (this.aborted) {
+      throw this.abortReason;
+    }
+
+    if (this.ws.readyState === WebSocket.CONNECTING) {
+      const { promise, resolve, reject } = Promise.withResolvers<void>();
+      const onOpen = () => {
+        this.ws.removeEventListener("open", onOpen);
+        this.ws.removeEventListener("error", onError);
+        resolve();
+      };
+      const onError = (ev: WebSocketEventMap["error"]) => {
+        console.log(ev);
+        this.ws.removeEventListener("open", onOpen);
+        this.ws.removeEventListener("error", onError);
+        reject(new Error("WebSocket failed to connect"));
+      };
+      this.ws.addEventListener("open", onOpen);
+      this.ws.addEventListener("error", onError);
+      await promise;
+    }
+
+    if (this.ws.readyState !== WebSocket.OPEN) {
+      throw new Error("WebSocket is not open");
+    }
+
+    await this.ws.send(message);
+  }
+
+  async receive(): Promise<string> {
+    if (this.aborted) {
+      throw this.abortReason;
+    }
+
+    const message = this.pendingMessages.shift();
+    if (message !== undefined) {
+      return message;
+    }
+    const { promise, resolve, reject } = Promise.withResolvers<string>();
+    if (this.aborted) {
+      reject(this.abortReason);
+    }
+    this.pendingReceiveRequests.push({ resolve, reject });
+    return promise;
+  }
+
+  abort(reason: any): void {
+    console.log("abort", reason);
+    if (this.aborted) return;
+
+    this.handleError(reason);
+    this.ws?.close();
+  }
+}
+
+// Handle WebSocket upgrade for RPC
+export function receiveRpcOverHttp(
+  request: Request,
+  target: RpcTarget
+): Response {
+  const upgradeHeader = request.headers.get("Upgrade");
+  if (upgradeHeader !== "websocket") {
+    return new Response("Expected WebSocket upgrade", { status: 400 });
+  }
+
+  const webSocketPair = new WebSocketPair();
+  const [client, server] = Object.values(webSocketPair);
+  server.accept();
+
+  const transport = new WebSocketTransport(server);
+
+  new RpcSession(transport, target);
+
+  return new Response(null, {
+    status: 101,
+    webSocket: client,
+  });
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,6 +7,7 @@
     "isolatedModules": true,
     "esModuleInterop": true,
     "strict": true,
+    "types": ["@cloudflare/workers-types/experimental"],
     "skipLibCheck": true
   },
   "include": ["src/**/*.ts", "__tests__/**/*.ts"],


### PR DESCRIPTION
Implement WebSocket transport and integrate with native types. There's a corresponding `workerd` PR on the way to actually implement `registerRpcTargetClass()`