### PR TITLE
Implement pipelined .map() operation.

### DIFF
--- a/__tests__/test-util.ts
+++ b/__tests__/test-util.ts
@@ -11,6 +11,10 @@ export class Counter extends RpcTarget {
     this.i += amount;
     return this.i;
   }
+
+  get value() {
+    return this.i;
+  }
 }
 
 // Distinct function so we can search for it in the stack trace.
@@ -38,4 +42,20 @@ export class TestTarget extends RpcTarget {
   incrementCounter(c: RpcStub<Counter>, i: number = 1) {
     return c.increment(i);
   }
+
+  generateFibonacci(length: number) {
+    let result = [0, 1];
+    if (length <= result.length) return result.slice(0, length);
+
+    while (result.length < length) {
+      let next = result[result.length - 1] + result[result.length - 2];
+      result.push(next);
+    }
+
+    return result;
+  }
+
+  returnNull() { return null; }
+  returnUndefined() { return undefined; }
+  returnNumber(i: number) { return i; }
 }

--- a/protocol.md
+++ b/protocol.md
@@ -123,6 +123,23 @@ If the type is "import", the expression evaluates to a stub. If it is "pipeline"
 
 `callArguments` is also optional. If specified, then the given property should be called as a function. `callArguments` is an expression that evaluates to an array; these are the arguments to the call.
 
+`["remap", importId, propertyPath, captures, instructions]`
+
+Implements the `.map()` operation. (We call this "remap" so as not to confuse with the serialization of a `Map` object.)
+
+`importId` and `propertyPath` are the same as for the `"import"` operation. These identify the particular property which is to be mapped.
+
+`captures` and `instructions` define the mapper function which is to apply to the target value.
+
+`captures` defines the set of stubs which the mapper function has captured, in the sense of a lambda capture. The body of the function may call these stubs. The format of `captures` is an array, where each member of the array is either `["import", importId]` or `["export", exportId]`, which refer to an entry on the (sender's) import or export table, respectively.
+
+`instructions` contains a list of expressions which should be evaluated to execute the mapper function on a particular input value. Each instruction is an expression in the same format described in this doc, but with special handling of imports and exports. For the purpose of the instructions in a mapper, there is no export table. The import table, meanwhile, is defined as follows:
+* Negative values refer to the `captures` list, starting from -1. So, -1 is `captures[0]`, -2 is `captures[1]`, and so on.
+* Zero refers to the input value of the map function.
+* Positive values refer to the results of previous instructions, starting from 1. So, 1 is the result of evaluating `instructions[0]`, 2 is the result of evaluating `instructions[1]`, and so on.
+
+The instructions are always evaluated in order. Each instruction may only import results of instructions that came before it. The last instruction evaluates to the return value of the map function.
+
 `["export", exportId]`
 
 The sender is exporting a new stub (or re-exporting a stub that was exported before). The expression evaluates to a stub.

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,6 +7,9 @@ import { newWebSocketRpcSession as newWebSocketRpcSessionImpl,
 import { newHttpBatchRpcSession as newHttpBatchRpcSessionImpl,
          newHttpBatchRpcResponse } from "./batch.js";
 import { newMessagePortRpcSession as newMessagePortRpcSessionImpl } from "./messageport.js";
+import { forceInitMap } from "./map.js";
+
+forceInitMap();
 
 // Re-export public API types.
 export { serialize, deserialize, newWorkersWebSocketRpcResponse, newHttpBatchRpcResponse };
@@ -18,7 +21,7 @@ export const RpcStub: {
   new <T extends Serializable<T>>(value: T): RpcStub<T>;
 } = <any>RpcStubImpl;
 
-export type RpcPromise<T extends Serializable<T>> = Stub<T> | Promise<Stubify<T>>;
+export type RpcPromise<T extends Serializable<T>> = Stub<T> & Promise<Stubify<T>>;
 export const RpcPromise: {
   // Note: Cannot construct directly!
 } = <any>RpcPromiseImpl;

--- a/src/map.ts
+++ b/src/map.ts
@@ -1,0 +1,341 @@
+import { StubHook, PropertyPath, RpcPayload, RpcStub, RpcPromise, withCallInterceptor, ErrorStubHook, mapImpl, PayloadStubHook, unwrapStubAndPath, unwrapStubNoProperties } from "./core.js";
+import { Devaluator, Exporter, Importer, ExportId, ImportId, Evaluator } from "./serialize.js";
+
+let currentMapBuilder: MapBuilder | undefined;
+
+// We use this type signature when building the instructions for type checking purposes. It
+// describes a subset of the overall RPC protocol.
+export type MapInstruction =
+    | ["pipeline", number, PropertyPath]
+    | ["pipeline", number, PropertyPath, unknown]
+    | ["remap", number, PropertyPath, ["import", number][], MapInstruction[]]
+
+class MapBuilder implements Exporter {
+  private context:
+    | {parent: undefined, captures: StubHook[], subject: StubHook, path: PropertyPath}
+    | {parent: MapBuilder, captures: number[], subject: number, path: PropertyPath};
+  private captureMap: Map<StubHook, number> = new Map();
+
+  private instructions: MapInstruction[] = [];
+
+  constructor(subject: StubHook, path: PropertyPath) {
+    if (currentMapBuilder) {
+      this.context = {
+        parent: currentMapBuilder,
+        captures: [],
+        subject: currentMapBuilder.capture(subject),
+        path
+      };
+    } else {
+      this.context = {
+        parent: undefined,
+        captures: [],
+        subject,
+        path
+      };
+    }
+
+    currentMapBuilder = this;
+  }
+
+  unregister() {
+    currentMapBuilder = this.context.parent;
+  }
+
+  makeInput(): MapVariableHook {
+    return new MapVariableHook(this, 0);
+  }
+
+  makeOutput(result: RpcPayload): StubHook {
+    let devalued: unknown;
+    try {
+      devalued = Devaluator.devaluate(result.value, undefined, this, result);
+    } finally {
+      result.dispose();
+    }
+
+    // The result is the final instruction. This doesn't actually fit our MapInstruction type
+    // signature, so we cheat a bit.
+    this.instructions.push(<any>devalued);
+
+    if (this.context.parent) {
+      this.context.parent.instructions.push(
+        ["remap", this.context.subject, this.context.path,
+                  this.context.captures.map(cap => ["import", cap]),
+                  this.instructions]
+      );
+      return new MapVariableHook(this.context.parent, this.context.parent.instructions.length);
+    } else {
+      return this.context.subject.map(this.context.path, this.context.captures, this.instructions);
+    }
+  }
+
+  pushCall(hook: StubHook, path: PropertyPath, params: RpcPayload): StubHook {
+    let devalued = Devaluator.devaluate(params.value, undefined, this, params);
+    // HACK: Since the args is an array, devaluator will wrap in a second array. Need to unwrap.
+    // TODO: Clean this up somehow.
+    devalued = (<Array<unknown>>devalued)[0];
+
+    let subject = this.capture(hook.dup());
+    this.instructions.push(["pipeline", subject, path, devalued]);
+    return new MapVariableHook(this, this.instructions.length);
+  }
+
+  pushGet(hook: StubHook, path: PropertyPath): StubHook {
+    let subject = this.capture(hook.dup());
+    this.instructions.push(["pipeline", subject, path]);
+    return new MapVariableHook(this, this.instructions.length);
+  }
+
+  capture(hook: StubHook): number {
+    if (hook instanceof MapVariableHook && hook.mapper === this) {
+      // Oh, this is already our own hook.
+      return hook.idx;
+    }
+
+    // TODO: Well, the hooks passed in are always unique, so they'll never exist in captureMap.
+    //   I suppose this is a problem with RPC as well. We need a way to identify hooks that are
+    //   dupes of the same target.
+    let result = this.captureMap.get(hook);
+    if (result === undefined) {
+      if (this.context.parent) {
+        let parentIdx = this.context.parent.capture(hook);
+        this.context.captures.push(parentIdx);
+      } else {
+        this.context.captures.push(hook);
+      }
+      result = -this.context.captures.length;
+      this.captureMap.set(hook, result);
+    }
+    return result;
+  }
+
+  // ---------------------------------------------------------------------------
+  // implements Exporter
+
+  exportStub(hook: StubHook): ExportId {
+    // It appears someone did something like:
+    //
+    //     stub.map(x => { return x.doSomething(new MyRpcTarget()); })
+    //
+    // That... won't work. They need to do this instead:
+    //
+    //     using myTargetStub = new RpcStub(new MyRpcTarget());
+    //     stub.map(x => { return x.doSomething(myTargetStub.dup()); })
+    //
+    // TODO(someday): Consider carefully if the inline syntax is maybe OK. If so, perhaps the
+    //   serializer could try calling `getImport()` even for known-local hooks.
+    // TODO(someday): Do we need to support rpc-thenable somehow?
+    throw new Error(
+        "Can't construct an RpcTarget or RPC callback inside a mapper function. Try creating a " +
+        "new RpcStub outside the callback first, then using it inside the callback.");
+  }
+  exportPromise(hook: StubHook): ExportId {
+    return this.exportStub(hook);
+  }
+  getImport(hook: StubHook): ImportId | undefined {
+    return this.capture(hook);
+  }
+
+  unexport(ids: Array<ExportId>): void {
+    // Presumably this MapBuilder is cooked anyway, so we don't really have to release anything.
+  }
+
+  onSendError(error: Error): Error | void {
+    // TODO(someday): Can we use the error-sender hook from the RPC system somehow?
+  }
+};
+
+mapImpl.sendMap = (hook: StubHook, path: PropertyPath, func: (promise: RpcPromise) => unknown) => {
+  let builder = new MapBuilder(hook, path);
+  let result: RpcPayload;
+  try {
+    result = RpcPayload.fromAppReturn(withCallInterceptor(builder.pushCall.bind(builder), () => {
+      return func(new RpcPromise(builder.makeInput(), []));
+    }));
+  } finally {
+    builder.unregister();
+  }
+
+  // Detect misuse: Map callbacks cannot be async.
+  if (result instanceof Promise) {
+    // Squelch unhanlded rejections from the map function itself -- it'll probably just throw
+    // something about pulling a MapVariableHook.
+    result.catch(err => {});
+
+    // Throw an understandable error.
+    throw new Error("RPC map() callbacks cannot be async.");
+  }
+
+  return new RpcPromise(builder.makeOutput(result), []);
+}
+
+function throwMapperBuilderUseError(): never {
+  throw new Error(
+      "Attempted to use an abstract placeholder from a mapper function. Please make sure your " +
+      "map function has no side effects.");
+}
+
+// StubHook which represents a variable in a map function.
+class MapVariableHook extends StubHook {
+  constructor(public mapper: MapBuilder, public idx: number) {
+    super();
+  }
+
+  // We don't have anything we actually need to dispose, so dup() can just return the same hook.
+  dup(): StubHook { return this; }
+  dispose(): void {}
+
+  get(path: PropertyPath): StubHook {
+    // This can actually be invoked as part of serialization, so we'll need to support it.
+    if (path.length == 0) {
+      // Since this hook cannot be pulled anyway, and dispose() is a no-op, we can actually just
+      // return the same hook again to represent getting the empty path.
+      return this;
+    } else if (currentMapBuilder) {
+      return currentMapBuilder.pushGet(this, path);
+    } else {
+      throwMapperBuilderUseError();
+    }
+  }
+
+  // Other methods should never be called.
+  call(path: PropertyPath, args: RpcPayload): StubHook {
+    // Can't be called; all calls are incercepted.
+    throwMapperBuilderUseError();
+  }
+
+  map(path: PropertyPath, captures: StubHook[], instructions: unknown[]): StubHook {
+    // Can't be called; all map()s are incercepted.
+    throwMapperBuilderUseError();
+  }
+
+  pull(): RpcPayload | Promise<RpcPayload> {
+    // Map functions cannot await.
+    throwMapperBuilderUseError();
+  }
+
+  ignoreUnhandledRejections(): void {
+    // Probably never called but whatever.
+  }
+
+  onBroken(callback: (error: any) => void): void {
+    throwMapperBuilderUseError();
+  }
+}
+
+// =======================================================================================
+
+class MapApplicator implements Importer {
+  private variables: StubHook[];
+
+  constructor(private captures: StubHook[], input: StubHook) {
+    this.variables = [input];
+  }
+
+  dispose() {
+    for (let variable of this.variables) {
+      variable.dispose();
+    }
+  }
+
+  apply(instructions: unknown[]): RpcPayload {
+    try {
+      if (instructions.length < 1) {
+        throw new Error("Invalid empty mapper function.");
+      }
+
+      for (let instruction of instructions.slice(0, -1)) {
+        let payload = new Evaluator(this).evaluateCopy(instruction);
+
+        // The payload almost always contains a single stub. As an optimization, unwrap it.
+        if (payload.value instanceof RpcStub) {
+          let hook = unwrapStubNoProperties(payload.value);
+          if (hook) {
+            this.variables.push(hook);
+            continue;
+          }
+        }
+
+        this.variables.push(new PayloadStubHook(payload));
+      }
+
+      return new Evaluator(this).evaluateCopy(instructions[instructions.length - 1]);
+    } finally {
+      for (let variable of this.variables) {
+        variable.dispose();
+      }
+    }
+  }
+
+  importStub(idx: ImportId): StubHook {
+    // This implies we saw an "export" appear inside the body of a mapper function. This should be
+    // impossible because exportStub()/exportPromise() throw exceptions in MapBuilder.
+    throw new Error("A mapper function cannot refer to exports.");
+  }
+  importPromise(idx: ImportId): StubHook {
+    return this.importStub(idx);
+  }
+
+  getExport(idx: ExportId): StubHook | undefined {
+    if (idx < 0) {
+      return this.captures[-idx - 1];
+    } else {
+      return this.variables[idx];
+    }
+  }
+}
+
+function applyMapToElement(input: unknown, parent: object | undefined, owner: RpcPayload | null,
+                           captures: StubHook[], instructions: unknown[]): RpcPayload {
+  // TODO(perf): I wonder if we could use .fromAppParams() instead of .deepCopyFrom()? It
+  //   maybe wouldn't correctly handle the case of RpcTargets in the input, so we need a variant
+  //   which takes an `owner`, which does add some complexity.
+  let inputHook = new PayloadStubHook(RpcPayload.deepCopyFrom(input, parent, owner));
+  let mapper = new MapApplicator(captures, inputHook);
+  try {
+    return mapper.apply(instructions);
+  } finally {
+    mapper.dispose();
+  }
+}
+
+mapImpl.applyMap = (input: unknown, parent: object | undefined, owner: RpcPayload | null,
+                    captures: StubHook[], instructions: unknown[]) => {
+  try {
+    let result: RpcPayload;
+    if (input instanceof RpcPromise) {
+      // The caller is responsible for making sure the input is not a promise, since we can't
+      // then know if it would resolve to an array later.
+      throw new Error("applyMap() can't be called on RpcPromise");
+    } else if (input instanceof Array) {
+      let payloads: RpcPayload[] = [];
+      try {
+        for (let elem of input) {
+          payloads.push(applyMapToElement(elem, input, owner, captures, instructions));
+        }
+      } catch (err) {
+        for (let payload of payloads) {
+          payload.dispose();
+        }
+        throw err;
+      }
+
+      result = RpcPayload.fromArray(payloads);
+    } else if (input === null || input === undefined) {
+      result = RpcPayload.fromAppReturn(input);
+    } else {
+      result = applyMapToElement(input, parent, owner, captures, instructions);
+    }
+
+    // TODO(perf): We should probably return a hook that allows pipelining but whose pull() doesn't
+    //   resolve until all promises in the payload have been substituted.
+    return new PayloadStubHook(result);
+  } finally {
+    for (let cap of captures) {
+      cap.dispose();
+    }
+  }
+}
+
+export function forceInitMap() {}


### PR DESCRIPTION
Copied from the readme:

### The magic `map()` method

Every RPC promise has a special method `.map()` which can be used to remotely transform a value, without pulling it back locally. Here's an example:

```ts
// Get a list of user IDs.
let idsPromise = api.listUserIds();

// Look up the username for each one.
let names = await idsPromise.map(id => [id, api.getUserName(id)]);
```

This example calls one API method to get a list of user IDs, then, for each user ID in the list, makes another RPC call to look up the user's name, producing a list of id/name pairs.

**All this happens in a single network round trip!**

`promise.map(func)` transfers a representation of `func` to the server, where it is executed on the promise's result. Specifically:

* If the promise resolves to an array, the mapper function executes on each element of the array. The overall `.map()` operation returns a promise for an array of the results.
* If the promise resolves to `null` or `undefined`, the map function is not executed at all. The result is the same value.
* If the promise resolves to any other value, the map function executes once on that value, returning the result.

Thus, `map()` can be used both for handling arrays, and for handling nullable values.

There are some restrictions:

* The callback must have no side effects other than calling RPCs.
* The callback must be synchronous. It cannot await anything.
* The input to the callback is an `RpcPromise`, hence the callback cannot actually operate on it, other than to invoke its RPC methods, or to use it in the params of other RPC methods.
* Any stubs which you use in the callback -- and any parameters you pass to them -- will be sent to the peer. Be warned, a malicious peer can use these stubs for anything, not just calling your callback. Typically, it only makes sense to invoke stubs that came from the same peer originally, since this is what saves round-trips.

**How the heck does that work?**

Cap'n Web does NOT send arbitrary code over the wire!

The trick here is record-replay: On the calling side, Cap'n Web will invoke your callback once, in a special "recording" mode, passing in a special placeholder stub which records what you do with it. During the invocation, any RPCs invoked by the callback (on *any* stub) will not actually be executed, but will be recorded as an action the callback performs. Any stubs you use during the recording are "captured" as well. Once the callback returns, the recording and the capture list can then be sent to the peer, where the recording can then be replayed as needed to process individual results.

Since all of the not-yet-determined values seen by the callback are represented as `RpcPromise`s, the callback's behavior is deterministic. Any actual computation (arithmetic, branching, etc.) can't possibly use these promises as (meaningful) inputs, so would logically produce the same results for every invocation of the callback. Any such computation will actually end up being performed on the sending side, just once, with the results being imbued into the recording.
