### PR TITLE
failing test: can an answer promise roundtrip

### DIFF
--- a/__tests__/index.test.ts
+++ b/__tests__/index.test.ts
@@ -1403,3 +1403,21 @@ describe("MessagePorts", () => {
         new Error("Peer closed MessagePort connection."));
   });
 });
+
+describe("Roundtripped answer promise handling", () => {
+  it("can use a roundtripped answer promise", async () => {
+    const stub = new RpcStub(new TestTarget());
+
+    // Create a pipelined promise
+    let counterPromise = stub.makeCounter(5);
+    
+    // Echo the pipelined promise back
+    let echoedPromise = stub.echo(counterPromise);
+    
+    // Both should resolve to the same counter
+    let [counter, echoedCounter] = await Promise.all([counterPromise, echoedPromise]);
+
+    expect(await counter.increment()).toBe(6);
+    expect(await echoedCounter.increment()).toBe(7);
+  });
+});

--- a/__tests__/test-util.ts
+++ b/__tests__/test-util.ts
@@ -62,4 +62,9 @@ export class TestTarget extends RpcTarget {
   returnNull() { return null; }
   returnUndefined() { return undefined; }
   returnNumber(i: number) { return i; }
+
+  echo(arg: any) {
+    return arg;
+  }
+
 }


### PR DESCRIPTION
encountered this edgecase while working on the OCapN js implementation, was curious how capnweb handled it.

There's room for argument on what the correct behavior is, but I find the current error message indicates a bug more than an appropriate assertion.

```
 FAIL   browsers-without-using (webkit)  __tests__/index.test.ts > roundtrip pipeline value handling > can return a pipelined promise unchanged
Error: Attempted to use RPC stub after it has been disposed.
 ❯ module code src/core.ts:241:14
    239| 
    240| const DISPOSED_HOOK: StubHook = new ErrorStubHook(
    241|     new Error("Attempted to use RPC stub after it has been disposed."));
       |              ^
    242| 
    243| // A call interceptor can be used to intercept all RPC stub invocations wit…

⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[6/6]⎯
```