### PR TITLE
Add missing await in node.js example code

### DIFF
--- a/README.md
+++ b/README.md
@@ -551,7 +551,7 @@ httpServer = http.createServer(async (request, response) => {
   // Accept Cap'n Web requests at `/api`.
   if (request.url === "/api") {
     try {
-      nodeHttpBatchRpcResponse(request, response, new MyApiImpl(), {
+      await nodeHttpBatchRpcResponse(request, response, new MyApiImpl(), {
         // If you are accepting WebSockets, then you might as well accept cross-origin HTTP, since
         // WebSockets always permit cross-origin request anyway. But, see security considerations
         // for further discussion.


### PR DESCRIPTION
Without this, the catch() doesn't actually catch exceptions, so they crash the server instead.

Fixes #26 (I think)