### PR TITLE
show and tell: rough sketch of third party handoff

### DIFF
--- a/src/websocket.ts
+++ b/src/websocket.ts
@@ -88,6 +88,10 @@ class WebSocketTransport implements RpcTransport {
   #receiveQueue: string[] = [];
   #error?: any;
 
+  getLocator(): string {
+    return this.#webSocket.url;
+  }
+
   async send(message: string): Promise<void> {
     if (this.#sendQueue === undefined) {
       this.#webSocket.send(message);


### PR DESCRIPTION
rough draft of third-party handoff for capnweb based on my experience writing an OCapN js implementation

### current status
basic test passes. no further work planned atm

### Basic Architecture
- Allows for opt-in Third Party Handoff support by having each client create a `SessionManager` and pass it to each session via `RpcSessionOptions`
- When a `SessionManager` has been specified and an import from third session is to be sent (eg via call args or return value), it instead:
  - generates a "swissnum" (shared secret) used for registering and redeeming a gift
  - send a "registerGift" message to the reference's host: `["registerGift", exportId, swissnum]`
  - serializes the reference as a "gift" type that species its host and swissnum: `["gift", locator, swissnum]`
  - upon receipt of a "gift" type, sending "redeemGift" message to the gift host: `["redeemGift", swissnum]`
  - upon receipt of a "redeemGift" message, resolving to registered gift value

### Implementation Details
 - each `SessionManager` is constructed with a `connectHook` for establishing a session from a locator
 - Adds a `getLocator()` method to `RpcTransport` to present a location string for the protocol + destination.
 - required making the target extractable from TargetStubHook. I couldn't find any other way of getting a PayloadStubHook to resolve to a TargetStubHook without throwing.

### Notes
- does not introduce 3-way e-order (neither does OCapN)
- likely requires all participating peers to have a SessionManager and be able to connect to a given locator
- OCapN handoffs sign the handoff for the recipient, here I'm assuming swissnum security is sufficient

### Not implemented
- handling `redeemGift` arriving before `registerGift` (due to networking latency)
- handoff of promises
- did not pay attention to hook cleanup / disposal
- session cleanup in SessionManager


