### PR TITLE
fix(types): Add default generic for untyped RPC sessions

### DIFF
--- a/__tests__/issue53.test.ts
+++ b/__tests__/issue53.test.ts
@@ -1,0 +1,66 @@
+// Copyright (c) 2025 Cloudflare, Inc.
+// Licensed under the MIT license found in the LICENSE.txt file or at:
+//     https://opensource.org/license/mit
+
+import { expect, it, describe } from "vitest";
+import { newHttpBatchRpcSession, newWebSocketRpcSession } from "../src/index.js";
+
+describe("Issue #53: Type instantiation excessively deep for untyped sessions", () => {
+  it("should not cause type instantiation errors for untyped HTTP batch sessions", () => {
+    // Before the fix, this would cause:
+    // "Type instantiation is excessively deep and possibly infinite.ts(2589)"
+    const httpSession = newHttpBatchRpcSession("http://example.com");
+    expect(httpSession).toBeDefined();
+
+    // RPC stubs are proxied functions, so they appear as "function" type
+    expect(typeof httpSession).toBe("function");
+  });
+
+  it("should not cause type instantiation errors for untyped WebSocket sessions", () => {
+    // This should work (already had default type parameter)
+    const wsSession = newWebSocketRpcSession("ws://example.com");
+    expect(wsSession).toBeDefined();
+
+    // RPC stubs are proxied functions, so they appear as "function" type
+    expect(typeof wsSession).toBe("function");
+  });
+
+  it("should work with explicit type parameters (typed sessions)", () => {
+    // Explicit typing should continue to work as before
+    interface MyApi {
+      ping(): Promise<string>;
+      getData(): Promise<number>;
+    }
+
+    const typedHttp = newHttpBatchRpcSession<MyApi>("http://example.com");
+    const typedWs = newWebSocketRpcSession<MyApi>("ws://example.com");
+
+    expect(typedHttp).toBeDefined();
+    expect(typedWs).toBeDefined();
+    expect(typeof typedHttp).toBe("function");
+    expect(typeof typedWs).toBe("function");
+
+    // These should have the correct types (checked at compile time)
+    // The calls themselves would fail at runtime since we're not connected to real servers,
+    // but TypeScript should accept them syntactically
+    expect(typeof typedHttp.ping).toBe("function");
+    expect(typeof typedWs.getData).toBe("function");
+  });
+
+  it("should return Empty-typed stubs for untyped sessions", () => {
+    // The untyped sessions should return RpcStub<Empty> which behaves like unknown
+    const httpSession = newHttpBatchRpcSession("http://example.com");
+    const wsSession = newWebSocketRpcSession("ws://example.com");
+
+    expect(httpSession).toBeDefined();
+    expect(wsSession).toBeDefined();
+
+    // These should be functions with RPC stub behavior (due to proxy)
+    expect(typeof httpSession).toBe("function");
+    expect(typeof wsSession).toBe("function");
+
+    // They should have the basic stub methods
+    expect(typeof httpSession.dup).toBe("function");
+    expect(typeof wsSession.dup).toBe("function");
+  });
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -117,7 +117,7 @@ export let newWebSocketRpcSession:<T extends Serializable<T> = Empty>
  * value is an RpcStub. You can customize anything about the request except for the method
  * (it will always be set to POST) and the body (which the RPC system will fill in).
  */
-export let newHttpBatchRpcSession:<T extends Serializable<T>>
+export let newHttpBatchRpcSession:<T extends Serializable<T> = Empty>
     (urlOrRequest: string | Request, init?: RequestInit) => RpcStub<T> =
     <any>newHttpBatchRpcSessionImpl;
 


### PR DESCRIPTION
**Resolves Issue #53**

This PR fixes a TypeScript compilation error that occurred when creating RPC sessions without an explicit type parameter.

## Problem

When `newHttpBatchRpcSession()` was called without a generic type, the TypeScript compiler would fail with the error:

```
"Type instantiation is excessively deep and possibly infinite.ts(2589)"
```

This happened because the function's generic `T extends Serializable<T>` did not have a default type. When TypeScript tried to infer `T`, the recursive nature of the `Serializable<T>` constraint caused an infinite loop in the type checker.

## Reproduction

```typescript
// Before fix - TypeScript compilation fails
import { newHttpBatchRpcSession } from "capnweb";
const http = newHttpBatchRpcSession("..."); // ❌ Type instantiation error
```

## Solution

This PR aligns the behavior of `newHttpBatchRpcSession` with `newWebSocketRpcSession` by adding `= Empty` as the default for the generic type parameter `T`.

```typescript
// src/index.ts
- export let newHttpBatchRpcSession<T extends Serializable<T>>
+ export let newHttpBatchRpcSession<T extends Serializable<T> = Empty>
```

This simple change provides a concrete type for TypeScript to use when one isn't specified, breaking the recursive loop and resolving the compilation error.

## Result

After this fix, both HTTP and WebSocket sessions can be created without explicit types, providing a consistent developer experience.

```typescript
// Both now work as expected for untyped sessions
const httpSession = newHttpBatchRpcSession("http://example.com"); // ✅ Works
const wsSession = newWebSocketRpcSession("ws://example.com");     // ✅ Still works

// Explicitly typed sessions are unaffected and continue to work correctly
interface MyApi { 
  ping(): Promise<string>; 
}
const typedHttp = newHttpBatchRpcSession<MyApi>("http://example.com"); // ✅ Still works
```

## Testing

Comprehensive test coverage has been added to `test/issue53.test.ts` to:

- ✅ Verify that both untyped and typed sessions can be created without errors
- ✅ Confirm that untyped sessions return the expected `RpcStub<Empty>` behavior
- ✅ Ensure that explicitly typed sessions continue to work as expected, preventing any regressions