### PR TITLE
fix(types): assignability error in tests stub

### DIFF
--- a/__tests__/index.test.ts
+++ b/__tests__/index.test.ts
@@ -673,7 +673,7 @@ describe("basic rpc", () => {
     expect(await stub.jsonify({x: 123, $remove$toJSON: () => "bad"})).toBe('{"x":123}');
   });
 
-  it("supports passing async functinos", async () => {
+  it("supports passing async functions", async () => {
     await using harness = new TestHarness(new TestTarget());
 
     async function square(i: number) {

--- a/__tests__/test-util.ts
+++ b/__tests__/test-util.ts
@@ -35,7 +35,7 @@ export class TestTarget extends RpcTarget {
     return { result: self.square(i) };
   }
 
-  async callFunction(func: RpcStub<(i: number) => number>, i: number) {
+  async callFunction(func: RpcStub<(i: number) => Promise<number>>, i: number) {
     return { result: await func(i) };
   }
 


### PR DESCRIPTION
I happened to notice there's a few errors in [`index.test.ts`](https://github.com/cloudflare/capnweb/blob/main/__tests__/index.test.ts).  Seems like that's because the build skips the tests (naturally) and vitest doesn't do typechecking. 

here's the error:
```
Argument of type '(i: number) => Promise<number>' is not assignable to parameter of type 'Unstubify<((i: Unstubify<number>) => Promise<number> & { toString: (radix?: Unstubify<number | undefined>) => Promise<string> & { [x: number]: Promise<...> & ... 2 more ... & StubBase<...>; ... 50 more ...; toWellFormed: () => Promise<...> & ... 2 more ... & StubBase<...>; } & { ...; } & StubBase<...>; ... 4 more .....'.
  Type '(i: number) => Promise<number>' is not assignable to type '(i: number) => number'.
    Type 'Promise<number>' is not assignable to type 'number'.ts(2345)
```

<img width="2867" height="1073" alt="image" src="https://github.com/user-attachments/assets/29454279-dcbd-4850-a554-5b1e3303f623" />