### PR TITLE
fix(types): filter symbol keys in RpcCompatible mapped type

### DIFF
--- a/.changeset/fix-rpccompatible-symbol-keys.md
+++ b/.changeset/fix-rpccompatible-symbol-keys.md
@@ -1,0 +1,5 @@
+---
+"capnweb": patch
+---
+
+Fix RpcCompatible type to filter out symbol keys instead of mapping them to never

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -33,7 +33,7 @@ export type RpcCompatible<T> =
   | Array<T extends Array<infer U> ? RpcCompatible<U> : never>
   | ReadonlyArray<T extends ReadonlyArray<infer U> ? RpcCompatible<U> : never>
   | {
-      [K in keyof T]: K extends number | string ? RpcCompatible<T[K]> : never;
+      [K in keyof T as K extends string | number ? K : never]: RpcCompatible<T[K]>;
     }
   | Promise<T extends Promise<infer U> ? RpcCompatible<U> : never>
   // Special types


### PR DESCRIPTION
## Summary

Use key remapping (`as` clause) to filter out symbol keys instead of mapping them to `never`. Fixes `Disposable` compatibility issue with RPC types.

## Context

Per @kentonv's [review comment](https://github.com/cloudflare/workerd/pull/5804#pullrequestreview-2735159492) on cloudflare/workerd#5804 - applying the same fix here.

## Change

```diff
- [K in keyof T]: K extends number | string ? RpcCompatible<T[K]> : never;
+ [K in keyof T as K extends string | number ? K : never]: RpcCompatible<T[K]>;
```

---

> [!NOTE]
> This PR was written with AI assistance.

<details><summary>AI Session Export</summary>
<p>

```json
{
  "info": {
    "title": "capnweb rpccompatible symbol fix",
    "agent": "opencode",
    "models": ["claude opus 4.5"]
  },
  "summary": [
    "user requested review of workerd PR #5804",
    "agent fetched PR details and Kenton's comment about updating capnweb",
    "agent cloned capnweb to ~/Code/work/ using jj",
    "agent applied same RpcCompatible fix to src/types.d.ts",
    "agent created PR referencing workerd#5804"
  ]
}
```

</p>
</details>