### PR TITLE
Add support for WireFormat + binaryBytes passthrough

### DIFF
--- a/src/batch.ts
+++ b/src/batch.ts
@@ -19,16 +19,16 @@ class BatchClientTransport implements RpcTransport {
   #batchToSend: string[] | null = [];
   #batchToReceive: string[] | null = null;
 
-  async send(message: string): Promise<void> {
+  async send(message: string | ArrayBuffer): Promise<void> {
     // If the batch was already sent, we just ignore the message, because throwing may cause the
     // RPC system to abort prematurely. Once the last receive() is done then we'll throw an error
     // that aborts the RPC system at the right time and will propagate to all other requests.
     if (this.#batchToSend !== null) {
-      this.#batchToSend.push(message);
+      this.#batchToSend.push(message as string);
     }
   }
 
-  async receive(): Promise<string> {
+  async receive(): Promise<string | ArrayBuffer> {
     if (!this.#batchToReceive) {
       await this.#promise;
     }
@@ -98,11 +98,11 @@ class BatchServerTransport implements RpcTransport {
   #batchToReceive: string[];
   #allReceived: PromiseWithResolvers<void> = Promise.withResolvers<void>();
 
-  async send(message: string): Promise<void> {
-    this.#batchToSend.push(message);
+  async send(message: string | ArrayBuffer): Promise<void> {
+    this.#batchToSend.push(message as string);
   }
 
-  async receive(): Promise<string> {
+  async receive(): Promise<string | ArrayBuffer> {
     let msg = this.#batchToReceive!.shift();
     if (msg !== undefined) {
       return msg;

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,7 +4,8 @@
 
 import { RpcTarget as RpcTargetImpl, RpcStub as RpcStubImpl, RpcPromise as RpcPromiseImpl } from "./core.js";
 import { serialize, deserialize } from "./serialize.js";
-import { RpcTransport, RpcSession as RpcSessionImpl, RpcSessionOptions } from "./rpc.js";
+import { RpcTransport, RpcSession as RpcSessionImpl, RpcSessionOptions, WireFormat,
+         jsonFormat } from "./rpc.js";
 import { RpcTargetBranded, RpcCompatible, Stub, Stubify, __RPC_TARGET_BRAND } from "./types.js";
 import { newWebSocketRpcSession as newWebSocketRpcSessionImpl,
          newWorkersWebSocketRpcResponse } from "./websocket.js";
@@ -17,8 +18,8 @@ forceInitMap();
 
 // Re-export public API types.
 export { serialize, deserialize, newWorkersWebSocketRpcResponse, newHttpBatchRpcResponse,
-         nodeHttpBatchRpcResponse };
-export type { RpcTransport, RpcSessionOptions, RpcCompatible };
+         nodeHttpBatchRpcResponse, jsonFormat };
+export type { RpcTransport, RpcSessionOptions, RpcCompatible, WireFormat };
 
 // Hack the type system to make RpcStub's types work nicely!
 /**


### PR DESCRIPTION
- Introduces a WireFormat interface so that users can plug in binary formats (e.g. CBOR)
- Widens all transports (RpcTransport, WebSocket, MessagePort, batch) from `string` to `string | ArrayBuffer`
- Adds binaryBytes option to pass Uint8Array through raw instead of base64-encoding
- Backwards compatible as jsonFormat is set as default. 

My main motivation was to be able to directly pass messages without having to message -> base64 -> stringify  - > parse -> decode -> message. 
If we use a package like CBOR, message -> encode -> decode (which is very fast) -> message, skipping the whole base64 encode and decode. This basically allows someone in the userland to define their own interface that works with RPC

```ts
  import { type WireFormat, newWebSocketRpcSession } from "capnweb";
  import { encode, decode } from "cbor2";

  const cborFormat: WireFormat = {
    encode(value: unknown): ArrayBuffer {
      return encode(value);
    },
    decode(data: string | ArrayBuffer): unknown {
      if (typeof data === "string") {
        throw new TypeError("cborFormat expects binary data, got string");
      }
      return decode(new Uint8Array(data));
    },
  };

  // Both sides must use the same format
  let stub = newWebSocketRpcSession<MyApi>("wss://example.com/rpc", undefined, {
    format: cborFormat,
    binaryBytes: true,  // pass Uint8Array raw instead of base64-encoding
  });

  let result = await stub.processImage(new Uint8Array(pixelData));
```


I did some benchmarks for this 

### Wire Size

| Scenario | JSON | CBOR | Savings |
|---|---:|---:|---:|
| Small RPC call (~40B) | 31 B | 22 B | 29% |
| Medium object (~2KB) | 1.3 KB | 916 B | 30% |
| Large binary (64KB) | 85.4 KB | 64.0 KB | 25% |
| OccupancyGrid (1024x1024) | 1.3 MB | 1.0 MB | 25% |
| PointCloud (50K pts, 800KB) | 1.0 MB | 781.4 KB | 25% |

### Performance

| Scenario | Op | JSON | CBOR | Winner |
|---|---|---:|---:|---|
| Small RPC (~40B) | encode | 125 ns | 3.28 µs | JSON 26x |
| | decode | 234 ns | 2.33 µs | JSON 10x |
| | full RT | 984 ns | 6.41 µs | JSON 7x |
| Medium obj (~2KB) | encode | 2.04 µs | 193.56 µs | JSON 95x |
| | decode | 4.82 µs | 35.62 µs | JSON 7x |
| | full RT | 11.40 µs | 238.23 µs | JSON 21x |
| Large binary (64KB) | encode | 9.59 µs | 29.85 µs | JSON 3x |
| | decode | 12.14 µs | 2.48 µs | **CBOR 5x** |
| | full RT | 44.04 µs | 36.57 µs | **CBOR 1.2x** |
| OccupancyGrid (1M) | encode | 152.82 µs | 369.45 µs | JSON 2x |
| | decode | 194.68 µs | 10.13 µs | **CBOR 19x** |
| | full RT | 783.11 µs | 395.57 µs | **CBOR 2x** |
| PointCloud (800KB) | encode | 121.17 µs | 245.80 µs | JSON 2x |
| | decode | 139.23 µs | 6.45 µs | **CBOR 22x** |
| | full RT | 554.20 µs | 255.84 µs | **CBOR 2x** |


P.S: Huge fan of your work btw!  Been following your work from capnproto days! 