### PR TITLE
fix(types): add callback contextual typing (#134)

### DIFF
--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -108,7 +108,9 @@ export type Stubify<T> =
 // `Stub` depends on `Provider`, which depends on `Unstubify`, which would depend on `Stub`.
 // prettier-ignore
 type UnstubifyInner<T> =
-  T extends StubBase<infer V> ? (T | V)  // can provide either stub or local RpcTarget
+  // Keep local RpcTarget acceptance, but avoid `Stub | Value` unions when the stub
+  // is already assignable to the value type (needed for callback contextual typing).
+  T extends StubBase<infer V> ? (T extends V ? V : (T | V))
   : T extends Map<infer K, infer V> ? Map<Unstubify<K>, Unstubify<V>>
   : T extends Set<infer V> ? Set<Unstubify<V>>
   : T extends [] ? []


### PR DESCRIPTION
Fixes #134 

As far as I'm aware, this should not cause any regressions in existing typing.