### PR TITLE
Move build format option to tsup config

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,8 +27,8 @@
     "access": "public"
   },
   "scripts": {
-    "build": "tsup --format esm,cjs",
-    "build:watch": "tsup --watch --format esm,cjs",
+    "build": "tsup",
+    "build:watch": "tsup --watch",
     "test": "vitest run",
     "test:watch": "vitest",
     "prepublishOnly": "npm run build"

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -6,7 +6,7 @@ import { defineConfig } from 'tsup'
 
 export default defineConfig({
   entry: ['src/index.ts', 'src/index-workers.ts'],
-  format: ['esm'],
+  format: ['esm', 'cjs'],
   external: ['cloudflare:workers'],
   dts: true,
   sourcemap: true,


### PR DESCRIPTION
Simple PR to move the formatting option to the tsup config. It doesn't make sense to hardcode `--format esm,cjs` twice in package.json which overrides the tsup config. It should be added in the tsup config directly. That hardcoded command was added in #107 [around here](https://github.com/cloudflare/capnweb/pull/107/changes#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R30).