### PR TITLE
fix: Handle cloudflare-internal:workers default export

### DIFF
--- a/.changeset/pink-teachers-sneeze.md
+++ b/.changeset/pink-teachers-sneeze.md
@@ -1,0 +1,5 @@
+---
+"capnweb": patch
+---
+
+fix: Handle `cloudflare-internal:workers` default export

--- a/src/core.ts
+++ b/src/core.ts
@@ -28,6 +28,8 @@ if (!Promise.withResolvers) {
 }
 
 let workersModule: any = (globalThis as any)[WORKERS_MODULE_SYMBOL];
+// Handle cloudflare-internal:workers which exports on `default` instead of named exports
+workersModule = workersModule?.default ?? workersModule;
 
 export interface RpcTarget {
   [__RPC_TARGET_BRAND]: never;


### PR DESCRIPTION
When running as a workerd extension module (like miniflare's `dispatch-namespace.worker.ts`), only `cloudflare-internal:workers` is available, rather than `cloudflare:workers`. It's easy enough for Miniflare to rewrite the capnpweb imports to `cloudflare-internal:workers` when bundling it's internal workers, but the `import *` approach causes problems, since the internal module exports everything on `default` rather than as named exports:

```javascript
// cloudflare:workers (regular workers)
import * as cfw from "cloudflare:workers";
cfw.RpcTarget // ✅ works

// cloudflare-internal:workers (extension modules)
import * as cfw from "cloudflare-internal:workers";
cfw.RpcTarget // ❌ undefined
cfw.default.RpcTarget // ✅ works
```

This change normalizes `workersModule` to handle both cases by checking for a `default` export first.