### PR TITLE
Fix type overrides for Uint8Array's toBase64 and fromBase64 leaking into capnweb's public interface.

### DIFF
--- a/.changeset/fluffy-masks-draw.md
+++ b/.changeset/fluffy-masks-draw.md
@@ -1,0 +1,5 @@
+---
+"capnweb": patch
+---
+
+Fixed type overrides for Uint8Array's toBase64 and fromBase64 leaking into capnweb's public interface.

--- a/__type-tests__/tsconfig.json
+++ b/__type-tests__/tsconfig.json
@@ -3,5 +3,5 @@
   "compilerOptions": {
     "noEmit": true
   },
-  "include": ["./**/*.ts"]
+  "include": ["./**/*.ts", "../src/base64-shims.d.ts"]
 }

--- a/src/base64-shims.d.ts
+++ b/src/base64-shims.d.ts
@@ -1,0 +1,30 @@
+// Copyright (c) 2026 Cloudflare, Inc.
+// Licensed under the MIT license found in the LICENSE.txt file or at:
+//     https://opensource.org/license/mit
+
+// Polyfill types for Uint8Array.toBase64() / Uint8Array.fromBase64(), which have started landing
+// in JS runtimes but are not supported everywhere just yet.
+//
+// This file is intentionally not imported by any source file. It is picked up by tsconfig.json's
+// include glob for our own compilation, but excluded from the published declaration bundle (which
+// only traces the import graph from entry points). This avoids leaking the optional toBase64 /
+// fromBase64 declarations into consumers' global types.
+
+declare global {
+  interface Uint8Array {
+    toBase64?(options?: {
+      alphabet?: "base64" | "base64url",
+      omitPadding?: boolean
+    }): string;
+  }
+
+  interface Uint8ArrayConstructor {
+    fromBase64?(text: string, options?: {
+      alphabet?: "base64" | "base64url",
+      lastChunkHandling?: "loose" | "strict" | "stop-before-partial"
+    }): Uint8Array;
+  }
+}
+
+// mark this file as a module so augmentation works correctly
+export {};

--- a/src/serialize.ts
+++ b/src/serialize.ts
@@ -52,24 +52,6 @@ const ERROR_TYPES: Record<string, any> = {
   // TODO: DOMError? Others?
 };
 
-// Polyfill types for Uint8Array.toBase64() / Uint8Array.fromBase64(), which have started landing
-// in JS runtimes but are not supported everywhere just yet.
-declare global {
-  interface Uint8Array {
-    toBase64?(options?: {
-      alphabet?: "base64" | "base64url",
-      omitPadding?: boolean
-    }): string;
-  }
-
-  interface Uint8ArrayConstructor {
-    fromBase64?(text: string, options?: {
-      alphabet?: "base64" | "base64url",
-      lastChunkHandling?: "loose" | "strict" | "stop-before-partial"
-    }): Uint8Array;
-  }
-}
-
 // Converts fully-hydrated messages into object trees that are JSON-serializable for sending over
 // the wire. This is used to implement serialization -- but it doesn't take the last step of
 // actually converting to a string. (The name is meant to be the opposite of "Evaluator", which


### PR DESCRIPTION
These type overrides were meant for type-checking Cap'n Web's own code, but the TS compiler "helpfully" shlepped them into the public `index.d.ts` for the capnweb package, affecting dependent builds. Oops!