### PR TITLE
Fix serialization for Invalid/NaN dates and incorrect peer abort error payload

### DIFF
--- a/__tests__/index.test.ts
+++ b/__tests__/index.test.ts
@@ -5,7 +5,7 @@
 import { expect, it, describe, inject } from "vitest"
 import { deserialize, serialize, RpcSession, type RpcSessionOptions, RpcTransport, RpcTarget,
          RpcStub, newWebSocketRpcSession, newMessagePortRpcSession,
-         newHttpBatchRpcSession} from "../src/index.js"
+         newHttpBatchRpcSession } from "../src/index.js"
 import { Counter, TestTarget } from "./test-util.js";
 
 let SERIALIZE_TEST_CASES: Record<string, unknown> = {
@@ -168,6 +168,16 @@ describe("simple serialization", () => {
     let deserialized = deserialize(serialized) as Uint8Array;
     expect(deserialized).toBeInstanceOf(Uint8Array);
     expect(new Uint8Array(deserialized)).toStrictEqual(new Uint8Array(buf));
+  })
+
+  it("preserves Invalid Date values through serialization", () => {
+    let invalidDate = new Date(NaN);
+    let serialized = serialize(invalidDate);
+    expect(serialized).toBe('["date",null]');
+
+    let deserialized = deserialize(serialized) as Date;
+    expect(deserialized).toBeInstanceOf(Date);
+    expect(Number.isNaN(deserialized.getTime())).toBe(true);
   })
 });
 
@@ -1499,6 +1509,25 @@ describe("onRpcBroken", () => {
       {which: "counter1", error: new Error("test disconnect")},
       {which: "hangingCall", error: new Error("test disconnect")},
     ]);
+  });
+
+  it("propagates remote abort reasons to onRpcBroken", async () => {
+    let clientTransport = new TestTransport("client");
+    let serverTransport = new TestTransport("server", clientTransport);
+
+    let client = new RpcSession<TestTarget>(clientTransport);
+    new RpcSession(serverTransport, new TestTarget());
+
+    let stub = client.getRemoteMain();
+    let brokenPromise = new Promise(resolve => {
+      stub.onRpcBroken(resolve);
+    });
+
+    await clientTransport.send('["bogus"]');
+
+    let error = await brokenPromise;
+    expect(error).toBeInstanceOf(Error);
+    expect(error).toStrictEqual(new Error('bad RPC message: ["bogus"]'));
   });
 });
 

--- a/src/rpc.ts
+++ b/src/rpc.ts
@@ -838,7 +838,7 @@ class RpcSessionImpl implements Importer, Exporter {
           case "abort": {
             let payload = new Evaluator(this).evaluate(msg[1]);
             payload.dispose();  // just in case -- should be no-op
-            this.abort(payload, false);
+            this.abort(payload.value, false);
             break;
           }
         }

--- a/src/serialize.ts
+++ b/src/serialize.ts
@@ -142,8 +142,10 @@ export class Devaluator {
       case "bigint":
         return ["bigint", (<bigint>value).toString()];
 
-      case "date":
-        return ["date", (<Date>value).getTime()];
+      case "date": {
+        let time = (<Date>value).getTime();
+        return ["date", Number.isNaN(time) ? null : time];
+      }
 
       case "bytes": {
         let bytes = value as Uint8Array;
@@ -496,6 +498,9 @@ export class Evaluator {
           }
           break;
         case "date":
+          if (value[1] === null) {
+            return new Date(NaN);
+          }
           if (typeof value[1] == "number") {
             return new Date(value[1]);
           }


### PR DESCRIPTION
Fixes #150 and also includes a fix for peer abort handling so `onRpcBroken()` receives the actual error