### PR TITLE
fix: websocket session and callback promise retention leak

### DIFF
--- a/__tests__/index.test.ts
+++ b/__tests__/index.test.ts
@@ -1308,6 +1308,36 @@ describe("stub disposal over RPC", () => {
   });
 });
 
+describe("callback calls", () => {
+  class CallbackTarget extends RpcTarget {
+    async callMany(callback: RpcStub<(text: string) => unknown>, count: number) {
+      let cb = callback.dup();
+      try {
+        for (let i = 0; i < count; ++i) {
+          cb(`value-${i}`);
+          await pumpMicrotasks();
+        }
+      } finally {
+        cb[Symbol.dispose]();
+      }
+    }
+  }
+
+  it("does not retain ignored synchronous callback results", async () => {
+    await using harness = new TestHarness(new CallbackTarget());
+    await harness.stub.callMany((_text: string) => {}, 5);
+    await pumpMicrotasks();
+    harness.checkAllDisposed();
+  });
+
+  it("does not retain ignored synchronous object callback results", async () => {
+    await using harness = new TestHarness(new CallbackTarget());
+    await harness.stub.callMany((text: string) => ({text}), 5);
+    await pumpMicrotasks();
+    harness.checkAllDisposed();
+  });
+});
+
 describe("e-order", () => {
   it("maintains e-order for concurrent calls on single stub", async () => {
     let callOrder: number[] = [];

--- a/src/rpc.ts
+++ b/src/rpc.ts
@@ -323,7 +323,7 @@ class RpcSessionImpl implements Importer, Exporter {
   private reverseExports: Map<StubHook, ExportId> = new Map();
   private imports: Array<ImportTableEntry> = [];
   private abortReason?: any;
-  private cancelReadLoop: (error: any) => void;
+  private cancelReadLoop?: (error: any) => void;
 
   // We assign positive numbers to imports we initiate, and negative numbers to exports we
   // initiate. So the next import ID is just `imports.length`, but the next export ID needs
@@ -348,11 +348,7 @@ class RpcSessionImpl implements Importer, Exporter {
     // Import zero is the other side's bootstrap object.
     this.imports.push(new ImportTableEntry(this, 0, false));
 
-    let rejectFunc: (error: any) => void;;
-    let abortPromise = new Promise<never>((resolve, reject) => { rejectFunc = reject; });
-    this.cancelReadLoop = rejectFunc!;
-
-    this.readLoop(abortPromise).catch(err => this.abort(err));
+    this.readLoop().catch(err => this.abort(err));
   }
 
   // Should only be called once immediately after construction.
@@ -684,7 +680,8 @@ class RpcSessionImpl implements Importer, Exporter {
     // Don't double-abort.
     if (this.abortReason !== undefined) return;
 
-    this.cancelReadLoop(error);
+    this.cancelReadLoop?.(error);
+    this.cancelReadLoop = undefined;
 
     if (trySendAbortMessage) {
       try {
@@ -734,9 +731,9 @@ class RpcSessionImpl implements Importer, Exporter {
     }
   }
 
-  private async readLoop(abortPromise: Promise<never>) {
+  private async readLoop() {
     while (!this.abortReason) {
-      let msg = JSON.parse(await Promise.race([this.transport.receive(), abortPromise]));
+      let msg = JSON.parse(await this.receiveOrAbort());
       if (this.abortReason) break;  // check again before processing
 
       if (msg instanceof Array) {
@@ -846,6 +843,27 @@ class RpcSessionImpl implements Importer, Exporter {
 
       throw new Error(`bad RPC message: ${JSON.stringify(msg)}`);
     }
+  }
+
+  // Use a fresh cancellation promise for each read. Reusing one session-long promise here causes
+  // Promise.race() to accumulate reactions until the session is shut down.
+  private receiveOrAbort(): Promise<string> {
+    let readCanceled = Promise.withResolvers<never>();
+    this.cancelReadLoop = readCanceled.reject;
+
+    let receivePromise: Promise<string>;
+    try {
+      receivePromise = this.transport.receive();
+    } catch (err) {
+      this.cancelReadLoop = undefined;
+      return Promise.reject(err);
+    }
+
+    return Promise.race([receivePromise, readCanceled.promise]).finally(() => {
+      if (this.cancelReadLoop === readCanceled.reject) {
+        this.cancelReadLoop = undefined;
+      }
+    });
   }
 
   async drain(): Promise<void> {

--- a/src/rpc.ts
+++ b/src/rpc.ts
@@ -581,6 +581,17 @@ class RpcSessionImpl implements Importer, Exporter {
     return msgText.length;
   }
 
+  private isDirectFunctionCall(expression: unknown): boolean {
+    if (!(expression instanceof Array)) return false;
+
+    let [kind, _id, path, args] = expression;
+    return kind === "pipeline" &&
+        expression.length === 4 &&
+        path instanceof Array &&
+        path.length === 0 &&
+        args instanceof Array;
+  }
+
   sendCall(id: ImportId, path: PropertyPath, args?: RpcPayload): RpcImportHook {
     if (this.abortReason) throw this.abortReason;
 
@@ -748,7 +759,13 @@ class RpcSessionImpl implements Importer, Exporter {
               // treated as an unhandled rejection on our end.
               hook.ignoreUnhandledRejections();
 
+              let exportId = this.exports.length;
               this.exports.push({ hook, refcount: 1 });
+              if (this.isDirectFunctionCall(msg[1])) {
+                // Direct function calls can be resolved immediately. This lets unused results
+                // be released right away instead of staying alive for the rest of the session.
+                this.ensureResolvingExport(exportId);
+              }
               continue;
             }
             break;

--- a/src/rpc.ts
+++ b/src/rpc.ts
@@ -744,7 +744,20 @@ class RpcSessionImpl implements Importer, Exporter {
 
   private async readLoop() {
     while (!this.abortReason) {
-      let msg = JSON.parse(await this.receiveOrAbort());
+      // Each receive needs its own abort promise so Promise.race() doesn't keep old reads.
+      let readCanceled = Promise.withResolvers<never>();
+      this.cancelReadLoop = readCanceled.reject;
+
+      let msgText: string;
+      try {
+        msgText = await Promise.race([this.transport.receive(), readCanceled.promise]);
+      } finally {
+        if (this.cancelReadLoop === readCanceled.reject) {
+          this.cancelReadLoop = undefined;
+        }
+      }
+
+      let msg = JSON.parse(msgText);
       if (this.abortReason) break;  // check again before processing
 
       if (msg instanceof Array) {
@@ -860,27 +873,6 @@ class RpcSessionImpl implements Importer, Exporter {
 
       throw new Error(`bad RPC message: ${JSON.stringify(msg)}`);
     }
-  }
-
-  // Use a fresh cancellation promise for each read. Reusing one session-long promise here causes
-  // Promise.race() to accumulate reactions until the session is shut down.
-  private receiveOrAbort(): Promise<string> {
-    let readCanceled = Promise.withResolvers<never>();
-    this.cancelReadLoop = readCanceled.reject;
-
-    let receivePromise: Promise<string>;
-    try {
-      receivePromise = this.transport.receive();
-    } catch (err) {
-      this.cancelReadLoop = undefined;
-      return Promise.reject(err);
-    }
-
-    return Promise.race([receivePromise, readCanceled.promise]).finally(() => {
-      if (this.cancelReadLoop === readCanceled.reject) {
-        this.cancelReadLoop = undefined;
-      }
-    });
   }
 
   async drain(): Promise<void> {


### PR DESCRIPTION
This PR fixes #153, a client-side memory leak in long-lived RPC sessions.

The session read loop was racing each `transport.receive()` call against a single session-long abort promise, which caused `Promise.race()` to accumulate until the entire session was disposed. This changes `RpcSession` to use a fresh cancellation promise for each pending read.

Edit: I also noticed another issue with callbacks causing a memory leak which isn't specifically reproduced in #153 which has been patched in this PR too.

Essentially if you had something like this where the callback is called regularly:
```ts
subscribeToTicks(cb: RpcStub<(ts: number) => void>) {
    const callback = cb.dup();

    let running = true;
    (async () => {
        while (running) {
            callback(Date.now());
            await new Promise(resolve => setTimeout(resolve, 100));
        }
    })()

    function cleanup() {
        running = false;
        callback[Symbol.dispose]?.();
    }

    callback.onRpcBroken(() => { cleanup(); });
}
```

The client would subscribe and capnweb would keep the callback promises in memory even though the result cannot be used.