### PR TITLE
feat: add Blob serialization support over RPC

### DIFF
--- a/.changeset/blob-rpc-support.md
+++ b/.changeset/blob-rpc-support.md
@@ -1,0 +1,5 @@
+---
+"capnweb": minor
+---
+
+Add `Blob` as a serializable type over RPC. `Blob` objects can now be passed as call arguments and return values. The MIME type (`blob.type`) is preserved across the wire.

--- a/README.md
+++ b/README.md
@@ -201,6 +201,7 @@ The following types can be passed over RPC (in arguments or return values), and 
 * `Date`
 * `Uint8Array`
 * `Error` and its well-known subclasses
+* `Blob`
 * `ReadableStream` and `WritableStream`, with automatic flow control.
 * `Headers`, `Request`, and `Response` from the Fetch API.
 

--- a/__tests__/index.test.ts
+++ b/__tests__/index.test.ts
@@ -173,6 +173,27 @@ describe("simple serialization", () => {
 
 // =======================================================================================
 
+describe("blob serialization", () => {
+  it("rejects malformed blob wire values", () => {
+    // Missing parts.
+    expect(() => deserialize('["blob"]')).toThrowError();
+    expect(() => deserialize('["blob","text/plain"]')).toThrowError();
+    // Non-string MIME type.
+    expect(() => deserialize('["blob",123,["readable",0]]')).toThrowError();
+    // Extra parts.
+    expect(() => deserialize('["blob","text/plain",["readable",0],"extra"]')).toThrowError();
+  });
+
+  it("throws when serializing Blob without an RPC session", () => {
+    // The encoder always uses a pipe, which requires an active RPC session. `serialize()` routes
+    // through NULL_EXPORTER and therefore cannot support Blob — same as streams and stubs.
+    let blob = new Blob(["hello"], {type: "text/plain"});
+    expect(() => serialize(blob)).toThrowError("Cannot create pipes without an RPC session");
+  });
+});
+
+// =======================================================================================
+
 class TestTransport implements RpcTransport {
   constructor(public name: string, private partner?: TestTransport) {
     if (partner) {
@@ -2442,5 +2463,217 @@ describe("Fetch API types over RPC", () => {
     let result = await stub.receiveResponse(new Response(null, {status: 204}));
     expect(result.status).toBe(204);
     expect(result.hasBody).toBe(false);
+  });
+});
+
+// =======================================================================================
+
+describe("Blob over RPC", () => {
+  it("can send and receive a binary Blob", async () => {
+    await using harness = new TestHarness(new TestTarget());
+    let bytes = new TextEncoder().encode("hello from blob");
+    let blob = new Blob([bytes], {type: "application/octet-stream"});
+    using result = await harness.stub.echoBlob(blob);
+    expect(result).toBeInstanceOf(Blob);
+    expect(result.type).toBe("application/octet-stream");
+    expect(new Uint8Array(await result.arrayBuffer())).toStrictEqual(bytes);
+  });
+
+  it("preserves Blob MIME type", async () => {
+    await using harness = new TestHarness(new TestTarget());
+    let blob = new Blob(["<h1>hello</h1>"], {type: "text/html; charset=utf-8"});
+    using result = await harness.stub.echoBlob(blob);
+    expect(result.type).toBe("text/html; charset=utf-8");
+    expect(await result.text()).toBe("<h1>hello</h1>");
+  });
+
+  it("can send an empty Blob", async () => {
+    await using harness = new TestHarness(new TestTarget());
+    let blob = new Blob([], {type: "application/octet-stream"});
+    using result = await harness.stub.echoBlob(blob);
+    expect(result).toBeInstanceOf(Blob);
+    expect(result.size).toBe(0);
+    expect(result.type).toBe("application/octet-stream");
+  });
+
+  it("can send a Blob as part of a compound return value", async () => {
+    class BlobServer extends RpcTarget {
+      makePayload() {
+        return {
+          name: "test.txt",
+          blob: new Blob(["file content"], {type: "text/plain"}),
+          size: 12,
+        };
+      }
+    }
+
+    await using harness = new TestHarness(new BlobServer());
+    let stub = harness.stub as any;
+    let result = await stub.makePayload();
+    expect(result.name).toBe("test.txt");
+    expect(result.blob).toBeInstanceOf(Blob);
+    expect(result.blob.type).toBe("text/plain");
+    expect(await result.blob.text()).toBe("file content");
+    expect(result.size).toBe(12);
+  });
+
+  it("can send multiple Blobs in the same call", async () => {
+    // Each Blob produces its own RpcPromise entry in the Evaluator's `promises` list; all must
+    // resolve before the payload is delivered to user code.
+    class BlobCombiner extends RpcTarget {
+      async concatenate(a: Blob, b: Blob) {
+        let [textA, textB] = await Promise.all([a.text(), b.text()]);
+        return `${textA}|${textB}`;
+      }
+    }
+
+    await using harness = new TestHarness(new BlobCombiner());
+    let stub = harness.stub as any;
+    let result = await stub.concatenate(
+      new Blob(["hello"], {type: "text/plain"}),
+      new Blob(["world"], {type: "text/plain"}),
+    );
+    expect(result).toBe("hello|world");
+  });
+
+  it("can receive an array of Blobs in one return value", async () => {
+    // Multiple RpcPromise entries produced from a single return value, all substituted before
+    // the array reaches user code.
+    class BlobFactory extends RpcTarget {
+      makeBlobs() {
+        return [
+          new Blob(["first"],  {type: "text/plain"}),
+          new Blob(["second"], {type: "text/plain"}),
+          new Blob(["third"],  {type: "text/plain"}),
+        ];
+      }
+    }
+
+    await using harness = new TestHarness(new BlobFactory());
+    let stub = harness.stub as any;
+    let [b1, b2, b3] = await stub.makeBlobs();
+    expect(await b1.text()).toBe("first");
+    expect(await b2.text()).toBe("second");
+    expect(await b3.text()).toBe("third");
+  });
+
+  it("round-trips a Blob with no MIME type", async () => {
+    // new Blob([bytes]) leaves .type as "" — the empty string must survive the round-trip
+    // and not become undefined or null.
+    await using harness = new TestHarness(new TestTarget());
+    let bytes = new TextEncoder().encode("untyped content");
+    let blob = new Blob([bytes]);
+    expect(blob.type).toBe("");
+    using result = await harness.stub.echoBlob(blob);
+    expect(result.type).toBe("");
+    expect(new Uint8Array(await result.arrayBuffer())).toStrictEqual(bytes);
+  });
+
+  it("preserves every possible byte value through the pipe", async () => {
+    // All 256 possible byte values in a single Blob — verifies the pipe mechanism
+    // neither corrupts nor truncates any byte.
+    await using harness = new TestHarness(new TestTarget());
+    let bytes = new Uint8Array(256);
+    for (let i = 0; i < 256; i++) bytes[i] = i;
+    let blob = new Blob([bytes], {type: "application/octet-stream"});
+    using result = await harness.stub.echoBlob(blob);
+    expect(result.size).toBe(256);
+    expect(new Uint8Array(await result.arrayBuffer())).toStrictEqual(bytes);
+  });
+
+  it("can send a large Blob over RPC", async () => {
+    // 1 MB blob — exercises multi-chunk stream collection in streamToBlob().
+    // Timeout is raised because CI machines can be slow to pump 1 MB through the
+    // fake in-process transport (default 5 s is too tight on some runners).
+    // Skipped in workerd: the isolate drops its connection when a large in-process
+    // stream is pumped through it (infrastructure limit, not a code bug).
+    if (navigator.userAgent === "Cloudflare-Workers") return;
+    await using harness = new TestHarness(new TestTarget());
+    let size = 1024 * 1024;
+    let bytes = new Uint8Array(size);
+    for (let i = 0; i < size; i++) bytes[i] = i & 0xff;
+    let blob = new Blob([bytes], {type: "application/octet-stream"});
+    using result = await harness.stub.echoBlob(blob);
+    expect(result.size).toBe(size);
+    expect(new Uint8Array(await result.arrayBuffer())).toStrictEqual(bytes);
+  }, 30_000);
+
+  it("can pass a Blob through a local (loopback) stub", async () => {
+    // No network — payload goes through deepCopy() rather than the Evaluator. Blobs are
+    // immutable so deepCopy() returns them as-is, without going through the pipe path.
+    using stub = new RpcStub(new TestTarget());
+    let bytes = new TextEncoder().encode("loopback content");
+    let blob = new Blob([bytes], {type: "text/plain"});
+    let result = await stub.echoBlob(blob);
+    expect(result).toBeInstanceOf(Blob);
+    expect(result.type).toBe("text/plain");
+    expect(await result.text()).toBe("loopback content");
+    result[Symbol.dispose]();
+  });
+
+  it("disposing a result containing a Blob does not throw", async () => {
+    // Blobs have no owned resources; disposeImpl() must be a silent no-op.
+    class BlobServer extends RpcTarget {
+      makeBlob() { return new Blob(["hello"], {type: "text/plain"}); }
+    }
+
+    await using harness = new TestHarness(new BlobServer());
+    let stub = harness.stub as any;
+    let result = await stub.makeBlob();
+    expect(result).toBeInstanceOf(Blob);
+    // Dispose without reading — should never throw.
+    expect(() => result[Symbol.dispose]()).not.toThrow();
+  });
+
+  it("is encoded as a readable pipe on the wire", async () => {
+    // Verify the wire format: ["blob", type, ["readable", pipeId]] — always. There is no inline
+    // fast path; reading a Blob's bytes is inherently async so we always stream.
+    class Server extends RpcTarget {
+      receiveBlob(_blob: Blob) { return "ok"; }
+    }
+
+    let clientTransport = new TestTransport("client");
+    let serverTransport = new TestTransport("server", clientTransport);
+
+    let client = new RpcSession<Server>(clientTransport);
+    let server = new RpcSession(serverTransport, new Server());
+
+    serverTransport.fence();
+
+    let stub = client.getRemoteMain();
+    let blob = new Blob(["hello"], {type: "text/plain"});
+    let p = stub.receiveBlob(blob);
+
+    // The call message is dispatched synchronously (the pipe path does not require pre-reading
+    // bytes on the sending side), but yield once to be safe across environments.
+    await Promise.resolve();
+
+    let blobExpr: any = undefined;
+    for (let i = 0; i < serverTransport.pendingCount; i++) {
+      let msg = JSON.parse((serverTransport as any).queue[i]);
+      if (msg[0] === "push") {
+        let findBlob = (v: any): any => {
+          if (v instanceof Array && v[0] === "blob") return v;
+          if (v instanceof Array) for (let e of v) { let r = findBlob(e); if (r) return r; }
+          if (v && typeof v === "object") for (let k in v) { let r = findBlob(v[k]); if (r) return r; }
+          return undefined;
+        };
+        blobExpr = findBlob(msg);
+        if (blobExpr) break;
+      }
+    }
+
+    expect(blobExpr).toBeDefined();
+    expect(blobExpr[0]).toBe("blob");
+    expect(blobExpr[1]).toBe("text/plain");
+    expect(blobExpr[2]).toBeInstanceOf(Array);
+    expect(blobExpr[2][0]).toBe("readable");
+    expect(typeof blobExpr[2][1]).toBe("number"); // pipe ID
+
+    serverTransport.releaseFence();
+    await p;
+
+    stub[Symbol.dispose]();
+    await pumpMicrotasks();
   });
 });

--- a/__tests__/test-util.ts
+++ b/__tests__/test-util.ts
@@ -66,4 +66,9 @@ export class TestTarget extends RpcTarget {
   returnNull() { return null; }
   returnUndefined() { return undefined; }
   returnNumber(i: number) { return i; }
+
+  async echoBlob(blob: Blob): Promise<Blob> {
+    let bytes = await blob.arrayBuffer();
+    return new Blob([bytes], {type: blob.type});
+  }
 }

--- a/src/core.ts
+++ b/src/core.ts
@@ -38,8 +38,8 @@ export let RpcTarget = workersModule ? workersModule.RpcTarget : class {};
 export type PropertyPath = (string | number)[];
 
 type TypeForRpc = "unsupported" | "primitive" | "object" | "function" | "array" | "date" |
-    "bigint" | "bytes" | "stub" | "rpc-promise" | "rpc-target" | "rpc-thenable" | "error" |
-    "undefined" | "writable" | "readable" | "headers" | "request" | "response";
+    "bigint" | "bytes" | "blob" | "stub" | "rpc-promise" | "rpc-target" | "rpc-thenable" |
+    "error" | "undefined" | "writable" | "readable" | "headers" | "request" | "response";
 
 const AsyncFunction = (async function () {}).constructor;
 
@@ -47,6 +47,9 @@ const AsyncFunction = (async function () {}).constructor;
 // to accept as "bytes". In browsers, this is undefined, which won't match any prototype.
 let BUFFER_PROTOTYPE: object | undefined =
     typeof Buffer !== "undefined" ? Buffer.prototype : undefined;
+
+// Blob is available in every runtime we support (Node >=18, browsers, workerd).
+const BLOB_PROTOTYPE = Blob.prototype;
 
 export function typeForRpc(value: unknown): TypeForRpc {
   switch (typeof value) {
@@ -111,6 +114,9 @@ export function typeForRpc(value: unknown): TypeForRpc {
 
     case Response.prototype:
       return "response";
+
+    case BLOB_PROTOTYPE:
+      return "blob";
 
     // TODO: All other structured clone types.
 
@@ -947,6 +953,7 @@ export class RpcPayload {
       case "bigint":
       case "date":
       case "bytes":
+      case "blob":
       case "error":
       case "undefined":
         // immutable, no need to copy
@@ -1271,6 +1278,7 @@ export class RpcPayload {
       case "primitive":
       case "bigint":
       case "bytes":
+      case "blob":
       case "date":
       case "error":
       case "undefined":
@@ -1409,6 +1417,7 @@ export class RpcPayload {
       case "primitive":
       case "bigint":
       case "bytes":
+      case "blob":
       case "date":
       case "error":
       case "undefined":
@@ -1566,6 +1575,7 @@ function followPath(value: unknown, parent: object | undefined,
       case "primitive":
       case "bigint":
       case "bytes":
+      case "blob":
       case "date":
       case "error":
       case "headers":

--- a/src/core.ts
+++ b/src/core.ts
@@ -48,9 +48,6 @@ const AsyncFunction = (async function () {}).constructor;
 let BUFFER_PROTOTYPE: object | undefined =
     typeof Buffer !== "undefined" ? Buffer.prototype : undefined;
 
-// Blob is available in every runtime we support (Node >=18, browsers, workerd).
-const BLOB_PROTOTYPE = Blob.prototype;
-
 export function typeForRpc(value: unknown): TypeForRpc {
   switch (typeof value) {
     case "boolean":
@@ -115,7 +112,7 @@ export function typeForRpc(value: unknown): TypeForRpc {
     case Response.prototype:
       return "response";
 
-    case BLOB_PROTOTYPE:
+    case Blob.prototype:
       return "blob";
 
     // TODO: All other structured clone types.

--- a/src/serialize.ts
+++ b/src/serialize.ts
@@ -304,13 +304,13 @@ export class Devaluator {
       }
 
       case "blob": {
-        // Blobs are always streamed through a pipe. Reading a Blob's bytes is inherently async,
-        // so there's no way to preserve send-side e-order regardless of encoding; always using
-        // the pipe keeps the encoder synchronous (matching the wire semantics of a payload
-        // containing a promise).
+        // Blobs are streamed through a pipe. This allows very large blobs to be sent without
+        // causing excessively large individual messages nor blocking other messages in the
+        // meantime.
         //
-        // When devaluating via NULL_EXPORTER (i.e. `serialize()`), createPipe() throws
-        // "Cannot create pipes without an RPC session." — same behaviour as streams and stubs.
+        // Ideally, small Blobs would be inlined. But, there is no way to read a blob
+        // synchronously, and we MUST serialize the message synchronously. Hence, we have no choice
+        // but to use streaming even for small blobs.
         let blob = value as Blob;
         let readable = blob.stream();
         let hook = streamImpl.createReadableStreamHook(readable);
@@ -481,10 +481,13 @@ function fixBrokenRequestBody(request: Request, body: ReadableStream): RpcPromis
   return new RpcPromise(new PromiseStubHook(promise), []);
 }
 
-// Assemble a Blob from a pipe ReadableStream asynchronously, wrapped in an RpcPromise so it plugs
-// into the existing payload-delivery substitution machinery. Same pattern as
-// fixBrokenRequestBody() above: the caller pushes the returned RpcPromise into the Evaluator's
-// `promises` list, and deliverTo() replaces it with the resolved Blob before user code runs.
+// Unfortuntaely, even though Blobs can only be read asynchronously, there is no way to create
+// a blob backed by an asynchronous source; the bytes MUST all be provided upfront. This
+// effectively makes it impossible to manitain e-order when sending Blobs.
+//
+// As a compromise, we deliver a message as if it contained an RpcPromise that resolves to the
+// Blob. This has the effect that the RPC system will wait for the whole Blob to stream in before
+// delivering the message -- reusing the existing machinery for handling promises.
 function streamToBlobPromise(stream: ReadableStream, type: string): RpcPromise {
   let promise = streamToBlob(stream, type).then(blob => {
     return new PayloadStubHook(RpcPayload.fromAppReturn(blob));

--- a/src/serialize.ts
+++ b/src/serialize.ts
@@ -46,6 +46,17 @@ class NullExporter implements Exporter {
 
 const NULL_EXPORTER = new NullExporter();
 
+// Collect all bytes from a ReadableStream into a Blob with the given MIME type. Used on the
+// receive side to assemble a Blob from a pipe stream before delivering to user code.
+//
+// `Response` is a standard global in every runtime we support (Node >=18, browsers, workerd), so
+// we can rely on `Response.blob()` for the heavy lifting. `Response.blob()` may discard the
+// caller-specified MIME type, so we `slice()` to reattach it if needed.
+async function streamToBlob(stream: ReadableStream, type: string): Promise<Blob> {
+  let b = await new Response(stream).blob();
+  return b.type === type ? b : b.slice(0, b.size, type);
+}
+
 // Maps error name to error class for deserialization.
 const ERROR_TYPES: Record<string, any> = {
   Error, EvalError, RangeError, ReferenceError, SyntaxError, TypeError, URIError, AggregateError,
@@ -292,6 +303,21 @@ export class Devaluator {
         return ["response", body, init];
       }
 
+      case "blob": {
+        // Blobs are always streamed through a pipe. Reading a Blob's bytes is inherently async,
+        // so there's no way to preserve send-side e-order regardless of encoding; always using
+        // the pipe keeps the encoder synchronous (matching the wire semantics of a payload
+        // containing a promise).
+        //
+        // When devaluating via NULL_EXPORTER (i.e. `serialize()`), createPipe() throws
+        // "Cannot create pipes without an RPC session." — same behaviour as streams and stubs.
+        let blob = value as Blob;
+        let readable = blob.stream();
+        let hook = streamImpl.createReadableStreamHook(readable);
+        let importId = this.exporter.createPipe(readable, hook);
+        return ["blob", blob.type, ["readable", importId]];
+      }
+
       case "error": {
         let e = <Error>value;
 
@@ -451,6 +477,17 @@ function fixBrokenRequestBody(request: Request, body: ReadableStream): RpcPromis
     let bytes = new Uint8Array(arrayBuffer);
     let result = new Request(request, {body: bytes});
     return new PayloadStubHook(RpcPayload.fromAppReturn(result));
+  });
+  return new RpcPromise(new PromiseStubHook(promise), []);
+}
+
+// Assemble a Blob from a pipe ReadableStream asynchronously, wrapped in an RpcPromise so it plugs
+// into the existing payload-delivery substitution machinery. Same pattern as
+// fixBrokenRequestBody() above: the caller pushes the returned RpcPromise into the Evaluator's
+// `promises` list, and deliverTo() replaces it with the resolved Blob before user code runs.
+function streamToBlobPromise(stream: ReadableStream, type: string): RpcPromise {
+  let promise = streamToBlob(stream, type).then(blob => {
+    return new PayloadStubHook(RpcPayload.fromAppReturn(blob));
   });
   return new RpcPromise(new PromiseStubHook(promise), []);
 }
@@ -624,6 +661,23 @@ export class Evaluator {
           }
 
           return new Response(body as BodyInit | null, init as ResponseInit);
+        }
+
+        case "blob": {
+          // Wire format is strictly ["blob", type, ["readable", id]] — the encoder always streams
+          // bytes through a pipe, so the content expression must evaluate to a ReadableStream.
+          if (value.length !== 3 || typeof value[1] !== "string") break;
+          let contentType = value[1] as string;
+          let content = this.evaluateImpl(value[2], parent, property);
+          if (!(content instanceof ReadableStream)) {
+            throw new TypeError("Blob content must be serialized as a ReadableStream.");
+          }
+          // Reuse the RpcPromise infrastructure (same pattern as fixBrokenRequestBody): the
+          // payload-delivery machinery resolves the promise and substitutes the real Blob before
+          // user code sees the value.
+          let promise = streamToBlobPromise(content, contentType);
+          this.promises.push({promise, parent, property});
+          return promise;
         }
 
         case "import":

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -87,6 +87,7 @@ type BaseType =
   | Date
   | Error
   | RegExp
+  | Blob
   | ReadableStream<Uint8Array>
   | WritableStream<any>  // Chunk type can be any RPC-compatible type
   | Request


### PR DESCRIPTION
## Summary

Adds `Blob` as a first-class serializable type — `Blob` objects can now be passed as RPC call arguments and return values, with MIME type preserved across the wire.

## Wire format

```
["blob", "image/png", ["readable", 5]]
```

Bytes always stream through a pipe. Reading a Blob's bytes is inherently asynchronous, so the uniform pipe path keeps the encoder synchronous and matches the wire semantics of a payload containing a promise.

## E-order

The call message is sent synchronously (send-side e-order preserved). On the receiving end, the Evaluator wraps the pipe stream in an `RpcPromise` that resolves to the Blob; delivery to user code waits for all promises in the payload to resolve, same as any other payload containing a promise.