### PR TITLE
Repro for shared WebSocket session failure in workerd

### DIFF
--- a/__tests__/index.test.ts
+++ b/__tests__/index.test.ts
@@ -1537,6 +1537,36 @@ describe("WebSockets", () => {
       expect(await cap.incrementCounter(counter, 9)).toBe(13);
     }
   });
+
+  it("can handle the same high-byte-volume workload in Node", async () => {
+    let entries = 6000;
+    let concurrency = 100;
+    let payload = "0".repeat(500_000);
+    let url = `ws://${inject("testServerHost")}`;
+    let cap = newWebSocketRpcSession<TestTarget>(url);
+    let completed = 0;
+    let pending = new Set<Promise<void>>();
+
+    try {
+      for (let i = 0; i < entries; i++) {
+        while (pending.size >= concurrency) {
+          await Promise.race(pending);
+        }
+
+        let task = cap.store(`key-${i}`, payload)
+            .then(() => { completed += 1; })
+            .finally(() => pending.delete(task));
+
+        pending.add(task);
+      }
+
+      await Promise.all(pending);
+    } finally {
+      cap[Symbol.dispose]();
+    }
+
+    expect(completed).toBe(entries);
+  }, 60_000);
 });
 
 describe("MessagePorts", () => {

--- a/__tests__/test-server-workerd.js
+++ b/__tests__/test-server-workerd.js
@@ -52,6 +52,9 @@ export class TestTarget extends RpcTarget {
     this.env = env;
   }
 
+  // Accepts and discards a key/value pair. Used by the stress repro.
+  store(_key, _value) {}
+
   square(i) {
     return i * i;
   }

--- a/__tests__/test-util.ts
+++ b/__tests__/test-util.ts
@@ -27,6 +27,8 @@ function throwErrorImpl(): never {
 }
 
 export class TestTarget extends RpcTarget {
+  store(_key: string, _value: string) {}
+
   square(i: number) {
     return i * i;
   }
@@ -63,7 +65,13 @@ export class TestTarget extends RpcTarget {
     return result;
   }
 
-  returnNull() { return null; }
-  returnUndefined() { return undefined; }
-  returnNumber(i: number) { return i; }
+  returnNull() {
+    return null;
+  }
+  returnUndefined() {
+    return undefined;
+  }
+  returnNumber(i: number) {
+    return i;
+  }
 }

--- a/__tests__/workerd.test.ts
+++ b/__tests__/workerd.test.ts
@@ -298,4 +298,71 @@ describe("workerd RPC server", () => {
     expect(await Promise.all([promise1, promise2, promise3]))
         .toStrictEqual([36, 5, 9]);
   })
+
+  it("passes with a fresh websocket session per batch under the same load", async () => {
+    let entries = 6000;
+    let concurrency = 100;
+    let payload = "0".repeat(500_000);
+    let completed = 0;
+
+    while (completed < entries) {
+      let resp = await (<Env>env).testServer.fetch("http://foo", {headers: {Upgrade: "websocket"}});
+      let ws = resp.webSocket;
+      expect(ws).toBeTruthy();
+
+      ws!.accept();
+      let cap = newWebSocketRpcSession<WorkerdTestTarget>(ws!);
+
+      try {
+        let batchSize = Math.min(concurrency, entries - completed);
+
+        await Promise.all(
+            Array.from({length: batchSize}, (_, index) =>
+                cap.store(`key-${completed + index}`, payload))
+        );
+
+        completed += batchSize;
+      } finally {
+        cap[Symbol.dispose]();
+      }
+    }
+
+    expect(completed).toBe(entries);
+  }, 60_000)
+
+  it("fails with a shared websocket session under high byte volume", async () => {
+    let entries = 3000;
+    let concurrency = 100;
+    let payload = "0".repeat(500_000);
+    let completed = 0;
+
+    let resp = await (<Env>env).testServer.fetch("http://foo", {headers: {Upgrade: "websocket"}});
+    let ws = resp.webSocket;
+    expect(ws).toBeTruthy();
+
+    ws!.accept();
+    let cap = newWebSocketRpcSession<WorkerdTestTarget>(ws!);
+
+    let pending = new Set<Promise<void>>();
+
+    try {
+      for (let i = 0; i < entries; i++) {
+        while (pending.size >= concurrency) {
+          await Promise.race(pending);
+        }
+
+        let task = cap.store(`key-${i}`, payload)
+            .then(() => { completed += 1; })
+            .finally(() => pending.delete(task));
+
+        pending.add(task);
+      }
+
+      await Promise.all(pending);
+    } finally {
+      cap[Symbol.dispose]();
+    }
+
+    expect(completed).toBe(entries);
+  }, 240_000)
 });


### PR DESCRIPTION
Related to #158

This adds 3 tests to reproduce the behavior under large payload volume:

```sh
# failing workerd case using one shared WebSocket session under large payload volume
pnpm test -- --project workerd __tests__/workerd.test.ts -t "fails with a shared websocket session"

# passing workerd control using fresh WebSocket sessions per batch
pnpm test -- --project workerd __tests__/workerd.test.ts -t "passes with a fresh websocket session per batch"

# passing Node control using the same shared WebSocket session pattern
pnpm test -- --project node __tests__/index.test.ts -t "same high-byte-volume workload in Node"
```

For the failing test, you should see something like this:

```sh
[vpw:info] Starting isolated runtimes for 1...

<--- Last few GCs --->

[16746:0xbf21f4000]     1353 ms: Mark-Compact 1399.4 (1423.0) -> 1399.4 (1423.0) MB, pooled: 2.2 MB, 2.02 / 0.00 ms (average mu = 0.113, current mu = 0.000) allocation failure; GC in old space requested
[16746:0xbf21f4000]     1355 ms: Mark-Compact 1399.4 (1423.0) -> 1399.4 (1423.0) MB, pooled: 2.2 MB, 2.02 / 0.00 ms (average mu = 0.060, current mu = 0.001) allocation failure; GC in old space requested

workerd/jsg/setup.c++:38: fatal: V8 fatal error; location = Ineffective mark-compacts near heap limit; message = : allocation failed: JavaScript heap out of memory
*** Received signal #6: Abort trap: 6
stack: 19b073887 19af7884f 1038d1f0f 103d0c18b 103ee937f 103ee765b 103efb6a3 103efb42b 103efaf47 103ed0cb7 103fe8cfb 103fef2ff 103fef3eb 103fef3eb 103fe86db 103fe8417 103d85a23 103bd960b 170286f8f 103b75983 103c50977 103b6601b 103b3addb 103e550cf 103e559ab 103e55aeb 103e6b10f 103e6af7b 1038aa7cf

⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯ Unhandled Rejection ⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯
TypeError: fetch failed
 ❯ node_modules/.pnpm/undici@7.18.2/node_modules/undici/index.js:127:13
 ❯ process.processTicksAndRejections node:internal/process/task_queues:105:5
 ❯ MessagePort.<anonymous> [worker eval]:28:22

Caused by: Error: connect ECONNREFUSED 127.0.0.1:55534
 ❯ TCPConnectWrap.afterConnect [as oncomplete] node:net:1637:16
```