### PR TITLE
Add bun support

### DIFF
--- a/.changeset/popular-pears-wink.md
+++ b/.changeset/popular-pears-wink.md
@@ -1,0 +1,5 @@
+---
+"capnweb": minor
+---
+
+Added support for Bun's alternative WebSocket server API.

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,6 +24,9 @@ jobs:
           node-version: "22"
           cache: "npm"
 
+      - name: Setup Bun
+        run: npm install -g bun
+
       - name: Install dependencies
         run: npm ci
 
@@ -31,7 +34,7 @@ jobs:
         run: npm run build
 
       - name: Run tests
-        run: npm test
+        run: npm run test:ci
 
       - name: Run type tests
         run: npm run test:types

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Cap'n Web is a spiritual sibling to [Cap'n Proto](https://capnproto.org) (and is
 * That said, it integrates nicely with TypeScript.
 * Also unlike Cap'n Proto, Cap'n Web's underlying serialization is human-readable. In fact, it's just JSON, with a little pre-/post-processing.
 * It works over HTTP, WebSocket, and postMessage() out-of-the-box, with the ability to extend it to other transports easily.
-* It works in all major browsers, Cloudflare Workers, Node.js, and other modern JavaScript runtimes.
+* It works in all major browsers, Cloudflare Workers, Node.js, Bun, Deno, and other modern JavaScript runtimes.
 The whole thing compresses (minify+gzip) to under 10kB with no dependencies.
 
 Cap'n Web is more expressive than almost every other RPC system, because it implements an object-capability RPC model. That means it:
@@ -627,6 +627,71 @@ Deno.serve(async (req) => {
   }
 
   return new Response("Not Found", { status: 404 });
+});
+```
+
+### HTTP server on Bun
+
+Bun's server-side WebSocket API uses [callback-based handlers](https://bun.sh/docs/runtime/http/websockets) instead of the standard `addEventListener` interface. Cap'n Web provides `newBunWebSocketRpcHandler()` which returns a handler object you can pass directly to `Bun.serve()`.
+
+```ts
+import { RpcTarget, newBunWebSocketRpcHandler, newHttpBatchRpcResponse } from "capnweb";
+
+class MyApiImpl extends RpcTarget implements MyApi {
+  // ... define API, same as above ...
+}
+
+// Create a WebSocket handler that manages RPC sessions automatically.
+// The callback is invoked once per connection to create a fresh API instance.
+let rpcHandler = newBunWebSocketRpcHandler(() => new MyApiImpl());
+
+Bun.serve({
+  async fetch(req, server) {
+    let url = new URL(req.url);
+    if (url.pathname === "/api") {
+      // Upgrade WebSocket requests.
+      if (req.headers.get("upgrade")?.toLowerCase() === "websocket") {
+        if (server.upgrade(req)) return;
+        return new Response("WebSocket upgrade failed", { status: 500 });
+      }
+
+      // Handle HTTP batch requests.
+      let response = await newHttpBatchRpcResponse(req, new MyApiImpl());
+      response.headers.set("Access-Control-Allow-Origin", "*");
+      return response;
+    }
+
+    return new Response("Not Found", { status: 404 });
+  },
+
+  // Pass the handler directly — no manual wiring needed.
+  websocket: rpcHandler,
+});
+```
+
+```ts
+import { newBunWebSocketRpcSession, newHttpBatchRpcResponse, type RpcTarget, type BunWebSocketTransport } from "capnweb";
+
+class MyApiImpl extends RpcTarget implements MyApi {
+  // ... define API, same as above ...
+}
+
+type Data = { userId: string; transport?: BunWebSocketTransport<Data> };
+
+Bun.serve<Data>({
+  fetch(req, server) {
+    let userId = authenticate(req);
+    server.upgrade(req, { data: { userId } });
+  },
+  websocket: {
+    open(ws) {
+      let { stub, transport } = newBunWebSocketRpcSession(ws, new MyApiImpl());
+      ws.data.transport = transport;
+    },
+    message(ws, msg) { ws.data.transport?.dispatchMessage(msg); },
+    close(ws, code, reason) { ws.data.transport?.dispatchClose(code, reason); },
+    error(ws, err) { ws.data.transport?.dispatchError(err); },
+  },
 });
 ```
 

--- a/README.md
+++ b/README.md
@@ -669,32 +669,6 @@ Bun.serve({
 });
 ```
 
-```ts
-import { newBunWebSocketRpcSession, newHttpBatchRpcResponse, type RpcTarget, type BunWebSocketTransport } from "capnweb";
-
-class MyApiImpl extends RpcTarget implements MyApi {
-  // ... define API, same as above ...
-}
-
-type Data = { userId: string; transport?: BunWebSocketTransport<Data> };
-
-Bun.serve<Data>({
-  fetch(req, server) {
-    let userId = authenticate(req);
-    server.upgrade(req, { data: { userId } });
-  },
-  websocket: {
-    open(ws) {
-      let { stub, transport } = newBunWebSocketRpcSession(ws, new MyApiImpl());
-      ws.data.transport = transport;
-    },
-    message(ws, msg) { ws.data.transport?.dispatchMessage(msg); },
-    close(ws, code, reason) { ws.data.transport?.dispatchClose(code, reason); },
-    error(ws, err) { ws.data.transport?.dispatchError(err); },
-  },
-});
-```
-
 ### HTTP server on other runtimes
 
 Every runtime does HTTP handling and WebSockets a little differently, although most modern runtimes use the standard `Request` and `Response` types from the Fetch API, as well as the standard `WebSocket` API. You should be able to use these two functions (exported by `capnweb`) to implement both HTTP batch and WebSocket handling on all platforms:

--- a/__tests__/bun.test.ts
+++ b/__tests__/bun.test.ts
@@ -1,0 +1,339 @@
+// Copyright (c) 2026 Cloudflare, Inc.
+// Licensed under the MIT license found in the LICENSE.txt file or at:
+//     https://opensource.org/license/mit
+
+import { expect, it, test, describe, afterEach } from "bun:test";
+import { RpcTarget, RpcStub } from "../src/index.js";
+import {
+  BunWebSocketTransport,
+  newBunWebSocketRpcSession,
+  newBunWebSocketRpcHandler,
+  newWebSocketRpcSession,
+} from "../src/index-bun.js";
+import { TestTarget } from "./test-util.js";
+import type { Server, ServerWebSocket } from "bun";
+
+let servers: Server[] = [];
+
+afterEach(() => {
+  for (let server of servers) {
+    server.stop(true);
+  }
+  servers = [];
+});
+
+// Start a Bun server with the given WebSocket handler and return the URL.
+function startServer(
+    handler: ReturnType<typeof newBunWebSocketRpcHandler>,
+): string {
+  let server = Bun.serve({
+    port: 0,
+    fetch(req, server) {
+      if (server.upgrade(req)) return undefined as any;
+      return new Response("Not Found", { status: 404 });
+    },
+    websocket: handler,
+  });
+  servers.push(server);
+  return `ws://${server.hostname}:${server.port}`;
+}
+
+// Open a WebSocket client and wait for the connection to be established.
+function connect(url: string): Promise<WebSocket> {
+  return new Promise((resolve, reject) => {
+    let ws = new WebSocket(url);
+    ws.addEventListener("open", () => resolve(ws));
+    ws.addEventListener("error", reject);
+  });
+}
+
+// Start a server with the handler helper and return a connected RPC stub.
+async function startRpcSession(createMain: () => RpcTarget) {
+  let handler = newBunWebSocketRpcHandler(createMain);
+  let url = startServer(handler);
+  return newWebSocketRpcSession(url);
+}
+
+describe("BunWebSocketTransport", () => {
+  it("sends and receives messages through a real Bun ServerWebSocket", async () => {
+    // Stand up a simple echo server that bounces messages back through the
+    // transport's dispatch path, exercising real send/receive.
+    let serverTransport: BunWebSocketTransport | undefined;
+    let handler = {
+      open(ws: ServerWebSocket) {
+        ws.data = { transport: new BunWebSocketTransport(ws) };
+        serverTransport = ws.data.transport;
+      },
+      message(ws: ServerWebSocket, msg: string | Buffer) {
+        ws.data.transport.dispatchMessage(msg);
+      },
+      close(ws: ServerWebSocket, code: number, reason: string) {
+        ws.data.transport.dispatchClose(code, reason);
+      },
+      error(ws: ServerWebSocket, err: Error) {
+        ws.data.transport.dispatchError(err);
+      },
+    };
+
+    let url = startServer(handler);
+    let clientWs = await connect(url);
+
+    // Send a message from the client; the server handler dispatches it into the
+    // transport. Then read it back from the server transport to verify the real
+    // socket delivered it.
+    clientWs.send("hello from client");
+    let received = await serverTransport!.receive();
+    expect(received).toBe("hello from client");
+
+    // Send a second message to confirm queuing works.
+    clientWs.send("second");
+    expect(await serverTransport!.receive()).toBe("second");
+
+    clientWs.close();
+  });
+
+  it("rejects receive() when the client closes the connection", async () => {
+    let serverTransport: BunWebSocketTransport | undefined;
+    let handler = {
+      open(ws: ServerWebSocket) {
+        ws.data = { transport: new BunWebSocketTransport(ws) };
+        serverTransport = ws.data.transport;
+      },
+      message(ws: ServerWebSocket, msg: string | Buffer) {
+        ws.data.transport.dispatchMessage(msg);
+      },
+      close(ws: ServerWebSocket, code: number, reason: string) {
+        ws.data.transport.dispatchClose(code, reason);
+      },
+      error(ws: ServerWebSocket, err: Error) {
+        ws.data.transport.dispatchError(err);
+      },
+    };
+
+    let url = startServer(handler);
+    let clientWs = await connect(url);
+
+    let receivePromise = serverTransport!.receive();
+    clientWs.close(1000, "bye");
+    await expect(receivePromise).rejects.toThrow("Peer closed WebSocket");
+  });
+
+  it("closes the underlying socket with code 3000 when abort() is called", async () => {
+    let serverTransport: BunWebSocketTransport | undefined;
+    let closed = new Promise<{ code: number; reason: string }>((resolve) => {
+      let handler = {
+        open(ws: ServerWebSocket) {
+          ws.data = { transport: new BunWebSocketTransport(ws) };
+          serverTransport = ws.data.transport;
+        },
+        message() {},
+        close(ws: ServerWebSocket, code: number, reason: string) {
+          resolve({ code, reason });
+        },
+        error() {},
+      };
+      startServer(handler);
+    });
+
+    // The server was started inside the promise — grab the URL from the
+    // last registered server.
+    let url = `ws://${servers[servers.length - 1].hostname}:${servers[servers.length - 1].port}`;
+    await connect(url);
+
+    serverTransport!.abort!(new Error("test abort"));
+    let result = await closed;
+    expect(result.code).toBe(3000);
+    expect(result.reason).toBe("test abort");
+  });
+});
+
+describe("newBunWebSocketRpcSession", () => {
+  it("returns a stub and transport over a real connection", async () => {
+    let serverResult: { stub: any; transport: BunWebSocketTransport } | undefined;
+    let handler = {
+      open(ws: ServerWebSocket) {
+        serverResult = newBunWebSocketRpcSession(ws, new TestTarget());
+        ws.data = { transport: serverResult.transport };
+      },
+      message(ws: ServerWebSocket, msg: string | Buffer) {
+        ws.data.transport.dispatchMessage(msg);
+      },
+      close(ws: ServerWebSocket, code: number, reason: string) {
+        ws.data.transport.dispatchClose(code, reason);
+      },
+      error(ws: ServerWebSocket, err: Error) {
+        ws.data.transport.dispatchError(err);
+      },
+    };
+
+    let url = startServer(handler);
+    let clientWs = await connect(url);
+
+    expect(serverResult).toBeDefined();
+    expect(serverResult!.stub).toBeDefined();
+    expect(serverResult!.transport).toBeInstanceOf(BunWebSocketTransport);
+
+    clientWs.close();
+  });
+
+  it("supports a full RPC round-trip with manual handler wiring", async () => {
+    let handler = {
+      open(ws: ServerWebSocket) {
+        let { transport } = newBunWebSocketRpcSession(ws, new TestTarget());
+        ws.data = { transport };
+      },
+      message(ws: ServerWebSocket, msg: string | Buffer) {
+        ws.data.transport.dispatchMessage(msg);
+      },
+      close(ws: ServerWebSocket, code: number, reason: string) {
+        ws.data.transport.dispatchClose(code, reason);
+      },
+      error(ws: ServerWebSocket, err: Error) {
+        ws.data.transport.dispatchError(err);
+      },
+    };
+
+    let url = startServer(handler);
+    let stub: any = newWebSocketRpcSession(url);
+
+    expect(await stub.square(5)).toBe(25);
+    expect(await stub.square(3)).toBe(9);
+
+    stub[Symbol.dispose]();
+  });
+
+  it("propagates errors from the remote target over a real connection", async () => {
+    let handler = {
+      open(ws: ServerWebSocket) {
+        let { transport } = newBunWebSocketRpcSession(ws, new TestTarget());
+        ws.data = { transport };
+      },
+      message(ws: ServerWebSocket, msg: string | Buffer) {
+        ws.data.transport.dispatchMessage(msg);
+      },
+      close(ws: ServerWebSocket, code: number, reason: string) {
+        ws.data.transport.dispatchClose(code, reason);
+      },
+      error(ws: ServerWebSocket, err: Error) {
+        ws.data.transport.dispatchError(err);
+      },
+    };
+
+    let url = startServer(handler);
+    let stub: any = newWebSocketRpcSession(url);
+
+    await expect(Promise.resolve(stub.throwError())).rejects.toThrow("test error");
+
+    stub[Symbol.dispose]();
+  });
+
+  it("supports bi-directional RPC where the server calls a client-provided callback", async () => {
+    let handler = {
+      open(ws: ServerWebSocket) {
+        let { transport } = newBunWebSocketRpcSession(ws, new TestTarget());
+        ws.data = { transport };
+      },
+      message(ws: ServerWebSocket, msg: string | Buffer) {
+        ws.data.transport.dispatchMessage(msg);
+      },
+      close(ws: ServerWebSocket, code: number, reason: string) {
+        ws.data.transport.dispatchClose(code, reason);
+      },
+      error(ws: ServerWebSocket, err: Error) {
+        ws.data.transport.dispatchError(err);
+      },
+    };
+
+    let url = startServer(handler);
+    let stub: any = newWebSocketRpcSession(url);
+
+    let double = new RpcStub((x: number) => x * 2);
+    let result = await stub.callFunction(double, 7);
+    expect(await result.result).toBe(14);
+
+    stub[Symbol.dispose]();
+  });
+});
+
+describe("newBunWebSocketRpcHandler", () => {
+  it("returns an object with open, message, close, and error handlers", () => {
+    let handler = newBunWebSocketRpcHandler(() => new TestTarget());
+    expect(typeof handler.open).toBe("function");
+    expect(typeof handler.message).toBe("function");
+    expect(typeof handler.close).toBe("function");
+    expect(typeof handler.error).toBe("function");
+  });
+
+  it("serves RPC over a real Bun server", async () => {
+    let stub: any = await startRpcSession(() => new TestTarget());
+
+    expect(await stub.square(7)).toBe(49);
+    expect(await stub.square(3)).toBe(9);
+
+    stub[Symbol.dispose]();
+  });
+
+  it("creates a fresh API instance per connection", async () => {
+    let connectionCount = 0;
+    let handler = newBunWebSocketRpcHandler(() => {
+      connectionCount++;
+      return new TestTarget();
+    });
+    let url = startServer(handler);
+
+    let stub1: any = newWebSocketRpcSession(url);
+    await stub1.square(1);
+
+    let stub2: any = newWebSocketRpcSession(url);
+    await stub2.square(2);
+
+    expect(connectionCount).toBe(2);
+
+    stub1[Symbol.dispose]();
+    stub2[Symbol.dispose]();
+  });
+});
+
+describe("TestTarget integration", () => {
+  test("squares a number", async () => {
+    let stub: any = await startRpcSession(() => new TestTarget());
+    expect(await stub.square(4)).toBe(16);
+    stub[Symbol.dispose]();
+  });
+
+  test("creates a counter and increments it", async () => {
+    let stub: any = await startRpcSession(() => new TestTarget());
+    let counter = stub.makeCounter(10);
+    expect(await stub.incrementCounter(counter, 5)).toBe(15);
+    expect(await stub.incrementCounter(counter)).toBe(16);
+    stub[Symbol.dispose]();
+  });
+
+  test("propagates errors thrown by remote methods", async () => {
+    let stub: any = await startRpcSession(() => new TestTarget());
+    await expect(Promise.resolve(stub.throwError())).rejects.toThrow("test error");
+    stub[Symbol.dispose]();
+  });
+
+  test("invokes a remote method with another stub as an argument", async () => {
+    let stub: any = await startRpcSession(() => new TestTarget());
+    let result = await stub.callSquare(stub, 6);
+    expect(await result.result).toBe(36);
+    stub[Symbol.dispose]();
+  });
+
+  test("returns a Fibonacci sequence", async () => {
+    let stub: any = await startRpcSession(() => new TestTarget());
+    let fib = await stub.generateFibonacci(10);
+    expect(fib).toEqual([0, 1, 1, 2, 3, 5, 8, 13, 21, 34]);
+    stub[Symbol.dispose]();
+  });
+
+  test("correctly returns null, undefined, and plain numbers", async () => {
+    let stub: any = await startRpcSession(() => new TestTarget());
+    expect(await stub.returnNull()).toBe(null);
+    expect(await stub.returnUndefined()).toBe(undefined);
+    expect(await stub.returnNumber(42)).toBe(42);
+    stub[Symbol.dispose]();
+  });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@changesets/cli": "^2.29.8",
         "@cloudflare/vitest-pool-workers": "^0.12.10",
         "@cloudflare/workers-types": "^4.20260205.0",
+        "@types/bun": "^1.2.0",
         "@types/ws": "^8.18.1",
         "@vitest/browser": "^3.2.4",
         "pkg-pr-new": "^0.0.60",
@@ -2877,6 +2878,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/bun": {
+      "version": "1.3.11",
+      "resolved": "https://registry.npmjs.org/@types/bun/-/bun-1.3.11.tgz",
+      "integrity": "sha512-5vPne5QvtpjGpsGYXiFyycfpDF2ECyPcTSsFBMa0fraoxiQyMJ3SmuQIGhzPg2WJuWxVBoxWJ2kClYTcw/4fAg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bun-types": "1.3.11"
+      }
+    },
     "node_modules/@types/chai": {
       "version": "5.2.3",
       "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
@@ -3188,6 +3199,16 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/bun-types": {
+      "version": "1.3.11",
+      "resolved": "https://registry.npmjs.org/bun-types/-/bun-types-1.3.11.tgz",
+      "integrity": "sha512-1KGPpoxQWl9f6wcZh57LvrPIInQMn2TQ7jsgxqpRzg+l0QPOFvJVH7HmvHo/AiPgwXy+/Thf6Ov3EdVn1vOabg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
       }
     },
     "node_modules/bundle-require": {

--- a/package.json
+++ b/package.json
@@ -14,10 +14,12 @@
       "types": "./dist/index.d.ts",
       "import": {
         "workerd": "./dist/index-workers.js",
+        "bun": "./dist/index-bun.js",
         "default": "./dist/index.js"
       },
       "require": {
         "workerd": "./dist/index-workers.cjs",
+        "bun": "./dist/index-bun.cjs",
         "default": "./dist/index.cjs"
       }
     }
@@ -30,6 +32,8 @@
     "build": "tsup",
     "build:watch": "tsup --watch",
     "test": "vitest run",
+    "test:bun": "bun test __tests__/bun.test.ts",
+    "test:ci": "vitest run && bun test __tests__/bun.test.ts",
     "test:watch": "vitest",
     "test:types": "tsc -p __type-tests__/tsconfig.json --noEmit",
     "prepublishOnly": "npm run build"
@@ -39,6 +43,7 @@
     "@changesets/cli": "^2.29.8",
     "@cloudflare/vitest-pool-workers": "^0.12.10",
     "@cloudflare/workers-types": "^4.20260205.0",
+    "@types/bun": "^1.2.0",
     "@types/ws": "^8.18.1",
     "@vitest/browser": "^3.2.4",
     "pkg-pr-new": "^0.0.60",

--- a/package.json
+++ b/package.json
@@ -11,17 +11,19 @@
   ],
   "exports": {
     ".": {
-      "types": "./dist/index.d.ts",
-      "import": {
-        "workerd": "./dist/index-workers.js",
-        "bun": "./dist/index-bun.js",
-        "default": "./dist/index.js"
+      "workerd": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index-workers.js",
+        "require": "./dist/index-workers.cjs"
       },
-      "require": {
-        "workerd": "./dist/index-workers.cjs",
-        "bun": "./dist/index-bun.cjs",
-        "default": "./dist/index.cjs"
-      }
+      "bun": {
+        "types": "./dist/index-bun.d.ts",
+        "import": "./dist/index-bun.js",
+        "require": "./dist/index-bun.cjs"
+      },
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "require": "./dist/index.cjs"
     }
   },
   "type": "module",

--- a/src/bun.ts
+++ b/src/bun.ts
@@ -1,0 +1,135 @@
+// Copyright (c) 2026 Cloudflare, Inc.
+// Licensed under the MIT license found in the LICENSE.txt file or at:
+//     https://opensource.org/license/mit
+
+import { RpcStub } from "./core.js";
+import { RpcTransport, RpcSession, RpcSessionOptions } from "./rpc.js";
+import { RpcTargetBranded } from "./types.js";
+import type { ServerWebSocket } from "bun";
+
+/**
+ * Start an RPC session over a Bun ServerWebSocket.
+ *
+ * Returns both the stub and the transport. The transport must be wired to Bun's
+ * `WebSocketHandler` callbacks (`message`, `close`, `error`) by calling its
+ * `dispatchMessage`, `dispatchClose`, and `dispatchError` methods.
+ *
+ * For a zero-wiring alternative, see `newBunWebSocketRpcHandler`.
+ */
+export function newBunWebSocketRpcSession<T>(
+    ws: ServerWebSocket<T>, localMain?: any,
+    options?: RpcSessionOptions): { stub: RpcStub, transport: BunWebSocketTransport<T> } {
+  let transport = new BunWebSocketTransport<T>(ws);
+  let rpc = new RpcSession(transport, localMain, options);
+  return { stub: rpc.getRemoteMain(), transport };
+}
+
+type WsData = { __capnwebTransport: BunWebSocketTransport<WsData>, __capnwebStub: RpcStub };
+
+/**
+ * Create a Bun `WebSocketHandler` object that manages RPC sessions automatically.
+ *
+ * The returned object can be passed directly as the `websocket` option to `Bun.serve()`.
+ * A fresh `localMain` is created for each connection via the `createMain` callback.
+ * The transport is stored on `ws.data.__capnwebTransport`.
+ *
+ * @param createMain Called once per connection to create the main RPC interface for that client.
+ * @param options Optional RPC session options applied to every connection.
+ */
+export function newBunWebSocketRpcHandler(createMain: () => RpcTargetBranded, options?: RpcSessionOptions) {
+  return {
+    open(ws: ServerWebSocket<WsData>) {
+      let transport = new BunWebSocketTransport<WsData>(ws);
+      let rpc = new RpcSession(transport, createMain(), options);
+      ws.data = { __capnwebTransport: transport, __capnwebStub: rpc.getRemoteMain() };
+    },
+    message(ws: ServerWebSocket<WsData>, message: string | Buffer) {
+      ws.data.__capnwebTransport.dispatchMessage(message);
+    },
+    close(ws: ServerWebSocket<WsData>, code: number, reason: string) {
+      ws.data.__capnwebTransport.dispatchClose(code, reason);
+    },
+    error(ws: ServerWebSocket<WsData>, error: Error) {
+      ws.data.__capnwebTransport.dispatchError(error);
+    },
+  };
+}
+
+export class BunWebSocketTransport<T = undefined> implements RpcTransport {
+  constructor (ws: ServerWebSocket<T>) {
+    this.#ws = ws;
+  }
+
+  #ws: ServerWebSocket<T>;
+  #receiveResolver?: (message: string) => void;
+  #receiveRejecter?: (err: any) => void;
+  #receiveQueue: string[] = [];
+  #error?: any;
+
+  async send(message: string): Promise<void> {
+    this.#ws.send(message);
+  }
+
+  async receive(): Promise<string> {
+    if (this.#receiveQueue.length > 0) {
+      return this.#receiveQueue.shift()!;
+    } else if (this.#error) {
+      throw this.#error;
+    } else {
+      return new Promise<string>((resolve, reject) => {
+        this.#receiveResolver = resolve;
+        this.#receiveRejecter = reject;
+      });
+    }
+  }
+
+  abort?(reason: any): void {
+    let message: string;
+    if (reason instanceof Error) {
+      message = reason.message;
+    } else {
+      message = `${reason}`;
+    }
+    this.#ws.close(3000, message);
+
+    if (!this.#error) {
+      this.#error = reason;
+      // No need to call receiveRejecter(); RPC implementation will stop listening anyway.
+    }
+  }
+
+  dispatchMessage(data: string | Buffer): void {
+    if (this.#error) {
+      return;
+    }
+
+    let strData = typeof data === "string" ? data : data.toString("utf-8");
+
+    if (this.#receiveResolver) {
+      this.#receiveResolver(strData);
+      this.#receiveResolver = undefined;
+      this.#receiveRejecter = undefined;
+    } else {
+      this.#receiveQueue.push(strData);
+    }
+  }
+
+  dispatchClose(code: number, reason: string): void {
+    this.#receivedError(new Error(`Peer closed WebSocket: ${code} ${reason}`));
+  }
+
+  dispatchError(error: Error): void {
+    this.#receivedError(new Error(`WebSocket connection failed.`));
+  }
+
+  #receivedError(reason: any) {
+    if (!this.#error) {
+      this.#error = reason;
+      if (this.#receiveRejecter) {
+        this.#receiveRejecter(reason);
+        this.#receiveResolver = undefined;
+        this.#receiveRejecter = undefined;
+      }
+    }
+  }
+}

--- a/src/index-bun.ts
+++ b/src/index-bun.ts
@@ -1,0 +1,34 @@
+// Copyright (c) 2025 Cloudflare, Inc.
+// Licensed under the MIT license found in the LICENSE.txt file or at:
+//     https://opensource.org/license/mit
+
+export * from "./index.js";
+
+import type { ServerWebSocket } from "bun";
+import type { RpcSessionOptions } from "./rpc.js";
+import type { RpcCompatible } from "./types.js";
+import { newBunWebSocketRpcSession as newBunWebSocketRpcSessionImpl,
+         newBunWebSocketRpcHandler,
+         BunWebSocketTransport } from "./bun.js";
+
+export { newBunWebSocketRpcHandler, BunWebSocketTransport };
+
+// Re-declare with the proper type so callers get full typing.
+import type { RpcStub } from "./index.js";
+
+interface Empty {}
+
+/**
+ * Start an RPC session over a Bun ServerWebSocket.
+ *
+ * Returns both the RPC stub and the transport. The transport exposes `dispatchMessage`,
+ * `dispatchClose`, and `dispatchError` methods that must be wired to Bun's `WebSocketHandler`
+ * callbacks. For a zero-wiring alternative, use `newBunWebSocketRpcHandler` instead.
+ *
+ * @param ws The Bun ServerWebSocket from the `open` callback.
+ * @param localMain The main RPC interface to expose to the peer.
+ */
+export let newBunWebSocketRpcSession:<T extends RpcCompatible<T> = Empty, D = undefined>
+    (ws: ServerWebSocket<D>, localMain?: any,
+     options?: RpcSessionOptions) => { stub: RpcStub<T>, transport: BunWebSocketTransport<D> } =
+    <any>newBunWebSocketRpcSessionImpl;

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -5,7 +5,7 @@
 import { defineConfig } from 'tsup'
 
 export default defineConfig({
-  entry: ['src/index.ts', 'src/index-workers.ts'],
+  entry: ['src/index.ts', 'src/index-workers.ts', 'src/index-bun.ts'],
   format: ['esm', 'cjs'],
   external: ['cloudflare:workers'],
   dts: true,


### PR DESCRIPTION
Add Bun ServerWebSocket support to capnweb.

Bun's server-side WebSocket uses callback-based handlers registered on `Bun.serve()` rather than the standard `addEventListener` interface. Passing a Bun `ServerWebSocket` to `newWebSocketRpcSession()` silently fails because the event listeners never fire. (#61)

A new `BunWebSocketTransport` implements the `RpcTransport` interface using the same resolver pattern as the existing WebSocket and MessagePort transports. It exposes `dispatchMessage`, `dispatchClose`, and `dispatchError` methods that Bun's handler callbacks invoke to feed messages into the transport.

Two convenience functions sit on top of the transport. `newBunWebSocketRpcHandler()` returns a complete handler object you can pass straight to `Bun.serve()`, wiring everything up automatically via `ws.data`. `newBunWebSocketRpcSession()` returns the stub and transport for users who need custom handler logic.

The readme now documents both approaches and notes that Bun is a supported runtime.

#### Quick start with the handler helper

```ts
import { RpcTarget, newBunWebSocketRpcHandler } from "capnweb";

class MyApi extends RpcTarget {
  greet(name: string) { return `Hello, ${name}!`; }
}

let rpcHandler = newBunWebSocketRpcHandler(() => new MyApi());

Bun.serve({
  fetch(req, server) {
    if (server.upgrade(req)) return;
    return new Response("Not Found", { status: 404 });
  },
  websocket: rpcHandler,
});
```

#### Escape hatch with manual wiring

```ts
import { newBunWebSocketRpcSession, RpcTarget } from "capnweb";

class MyApi extends RpcTarget {
  greet(name: string) { return `Hello, ${name}!`; }
}

Bun.serve({
  fetch(req, server) {
    let userId = authenticate(req);
    server.upgrade(req, { data: { userId } });
  },
  websocket: {
    open(ws) {
      let { stub, transport } = newBunWebSocketRpcSession(ws, new MyApi());
      ws.data.transport = transport;
    },
    message(ws, msg) { ws.data.transport.dispatchMessage(msg); },
    close(ws, code, reason) { ws.data.transport.dispatchClose(code, reason); },
    error(ws, err) { ws.data.transport.dispatchError(err); },
  },
});
```

#### Testing locally

Run the test suite with `npm test`. The new tests in `__tests__/bun.test.ts` exercise the transport, both convenience functions, and full round-trip calls through a loopback pair without needing a real Bun server.

Unit tests cover message queuing, close and error propagation, abort semantics, buffer-to-string conversion, and end-to-end calls including bidirectional callbacks and error forwarding. All existing tests continue to pass.

Closes #61
