### PR TITLE
Preserve own properties of Error instances across serialization/deserialization

### DIFF
--- a/.changeset/error-own-properties.md
+++ b/.changeset/error-own-properties.md
@@ -1,0 +1,5 @@
+---
+"capnweb": patch
+---
+
+Errors properties, using `Object.keys()`, are now preserved across the wire. Attach fields like `code` or `details` to an `Error` and they propagate to the other side. The `cause` and `errors` (for `AggregateError`) properties will also be preserved.

--- a/__tests__/index.test.ts
+++ b/__tests__/index.test.ts
@@ -179,7 +179,7 @@ describe("simple serialization", () => {
     expect(deserialized).toBeInstanceOf(Date);
     expect(Number.isNaN(deserialized.getTime())).toBe(true);
   })
-});
+})
 
 // =======================================================================================
 
@@ -199,8 +199,213 @@ describe("blob serialization", () => {
     // through NULL_EXPORTER and therefore cannot support Blob — same as streams and stubs.
     let blob = new Blob(["hello"], {type: "text/plain"});
     expect(() => serialize(blob)).toThrowError("Cannot create pipes without an RPC session");
+  })
+})
+
+describe("error serialization", () => {
+  function roundTrip(err: Error): Error & Record<string, unknown> {
+    return deserialize(serialize(err)) as unknown as Error & Record<string, unknown>;
+  }
+
+  it("preserves dynamically-attached own properties", () => {
+    let err = new Error("the message") as Error & Record<string, unknown>;
+    err.code = "E_FOO";
+    err.details = { reason: "x", retries: 3 };
+
+    let result = roundTrip(err);
+    expect(result).toBeInstanceOf(Error);
+    expect(result.name).toBe("Error");
+    expect(result.message).toBe("the message");
+    expect(result.code).toBe("E_FOO");
+    expect(result.details).toStrictEqual({ reason: "x", retries: 3 });
   });
-});
+
+  it("preserves class-field properties on Error subclasses", () => {
+    class MyError extends Error {
+      code = "E_FOO";
+      foo = "bar";
+    }
+    let err = new MyError("boom");
+
+    let result = roundTrip(err);
+    // Subclass identity is not preserved and falls back to Error.
+    expect(result).toBeInstanceOf(Error);
+    expect(result.message).toBe("boom");
+    expect(result.code).toBe("E_FOO");
+    expect(result.foo).toBe("bar");
+  });
+
+  it("preserves built-in subclass identity when extras are present", () => {
+    let err = new TypeError("t") as TypeError & Record<string, unknown>;
+    err.code = 1;
+
+    let result = roundTrip(err);
+    expect(result).toBeInstanceOf(TypeError);
+    expect(result.name).toBe("TypeError");
+    expect(result.message).toBe("t");
+    expect(result.code).toBe(1);
+  });
+
+  it("emits the legacy 3-element form when there are no extras", () => {
+    let err = new Error("plain");
+    err.stack = undefined;
+    expect(serialize(err)).toBe('["error","Error","plain"]');
+  });
+
+  it("emits 5 elements with null stack when extras are present but stack is absent", () => {
+    let err = new Error("x") as Error & Record<string, unknown>;
+    err.stack = undefined;
+    err.code = "X";
+
+    let parsed = JSON.parse(serialize(err));
+    expect(parsed[0]).toBe("error");
+    expect(parsed[1]).toBe("Error");
+    expect(parsed[2]).toBe("x");
+    expect(parsed[3]).toBe(null);
+    expect(parsed[4]).toStrictEqual({ code: "X" });
+  });
+
+  it("round-trips nested supported types inside props", () => {
+    let err = new Error("nested") as Error & Record<string, unknown>;
+    err.when = new Date(1234);
+    err.big = 12345678901234567890n;
+    err.bytes = new TextEncoder().encode("hi!");
+    err.obj = { a: 1, b: [2, 3] };
+    err.inner = new TypeError("inner");
+
+    let result = roundTrip(err);
+    expect(result.when).toStrictEqual(new Date(1234));
+    expect(result.big).toBe(12345678901234567890n);
+    expect(new Uint8Array(result.bytes as Buffer)).toStrictEqual(new TextEncoder().encode("hi!"));
+    expect(result.obj).toStrictEqual({ a: 1, b: [2, 3] });
+
+    if (!(result.inner instanceof TypeError)) throw new Error("invariant");
+    expect(result.inner).toBeInstanceOf(TypeError);
+    expect(result.inner.message).toBe("inner");
+  });
+
+  it("is decodable by a legacy 4-element decoder (new sender -> old receiver)", () => {
+    // Mimic the pre-change decoder branch: only look at value[1..3], ignore the rest.
+    function legacyDecode(json: string): Error & Record<string, unknown> {
+      let value = JSON.parse(json);
+      if (value.length >= 3 && typeof value[1] === "string" && typeof value[2] === "string") {
+        let cls: any = { Error, TypeError, RangeError }[value[1]] || Error;
+        let result = new cls(value[2]);
+        if (typeof value[3] === "string") {
+          result.stack = value[3];
+        }
+        return result;
+      }
+      throw new Error("unparseable");
+    }
+
+    // Default `serialize` strips stack, so value[3] will be null. Old decoder's
+    // `typeof value[3] === "string"` check still passes (just doesn't fire), and value[4]
+    // is silently ignored. We're verifying the new shape doesn't break the old branch.
+    let err = new TypeError("t") as TypeError & Record<string, unknown>;
+    err.code = "X";
+
+    let decoded = legacyDecode(serialize(err));
+    expect(decoded).toBeInstanceOf(TypeError);
+    expect(decoded.message).toBe("t");
+    expect(decoded.code).toBeUndefined();
+  });
+
+  it("decodes legacy 3- and 4-element forms (old sender -> new receiver)", () => {
+    let three = deserialize('["error","Error","msg"]') as Error;
+    expect(three).toBeInstanceOf(Error);
+    expect(three.message).toBe("msg");
+
+    let four = deserialize('["error","TypeError","msg","trace"]') as Error;
+    expect(four).toBeInstanceOf(TypeError);
+    expect(four.message).toBe("msg");
+    expect(four.stack).toBe("trace");
+  });
+
+  it("throws when decoding an error with a malformed props bag", () => {
+    // A non-object/array `props` is structurally invalid; reject rather than silently ignore.
+    expect(() => deserialize('["error","Error","msg",null,"not-an-object"]'))
+        .toThrow(TypeError);
+    expect(() => deserialize('["error","Error","msg",null,42]'))
+        .toThrow(TypeError);
+    expect(() => deserialize('["error","Error","msg",null,[1,2]]'))
+        .toThrow(TypeError);
+    expect(() => deserialize('["error","Error","msg",null,null]'))
+        .toThrow(TypeError);
+  });
+
+  it("round-trips Error.cause", () => {
+    let inner = new TypeError("inner");
+    let outer = new Error("outer", { cause: inner });
+
+    let result = roundTrip(outer);
+    expect(result).toBeInstanceOf(Error);
+    expect(result.message).toBe("outer");
+
+    if (!(result.cause instanceof Error)) throw new Error("invariant");
+    expect(result.cause).toBeInstanceOf(TypeError);
+    expect(result.cause.message).toBe("inner");
+  });
+
+  it("round-trips a primitive cause", () => {
+    let err = new Error("oops", { cause: "boom" });
+    let result = roundTrip(err);
+    expect(result.cause).toBe("boom");
+  });
+
+  it("round-trips AggregateError.errors with inner subclass identity", () => {
+    let agg = new AggregateError([new TypeError("a"), new RangeError("b")], "agg");
+    let result = roundTrip(agg);
+
+    if (!(result instanceof AggregateError)) throw new Error("invariant");
+    expect(result).toBeInstanceOf(AggregateError);
+    expect(result.message).toBe("agg");
+    expect(Array.isArray(result.errors)).toBe(true);
+    expect(result.errors).toHaveLength(2);
+    expect(result.errors[0]).toBeInstanceOf(TypeError);
+    expect(result.errors[0].message).toBe("a");
+    expect(result.errors[1]).toBeInstanceOf(RangeError);
+    expect(result.errors[1].message).toBe("b");
+  });
+
+  it("silently drops properties whose values cannot be serialized", () => {
+    let err = new Error("with-bad-prop") as Error & Record<string, unknown>;
+    err.code = "E_OK";
+    err.bad = Object.create(null);
+
+    let serialized = serialize(err);
+    let result = deserialize(serialized) as Error & Record<string, unknown>;
+
+    expect(result).toBeInstanceOf(Error);
+    expect(result.message).toBe("with-bad-prop");
+    expect(result.code).toBe("E_OK");
+    expect("bad" in result).toBe(false);
+  });
+
+  it("silently drops cyclic property values", () => {
+    let err = new Error("cyclic") as Error & Record<string, unknown>;
+    err.code = "E_OK";
+    let cycle: any = {};
+    cycle.self = cycle;
+    err.cycle = cycle;
+
+    let result = roundTrip(err);
+    expect(result.message).toBe("cyclic");
+    expect(result.code).toBe("E_OK");
+    expect("cycle" in result).toBe(false);
+  });
+
+  it("never throws even when every extra property is unsupported", () => {
+    let err = new Error("all-bad") as Error & Record<string, unknown>;
+    err.a = Object.create(null);
+    err.b = Symbol("x");
+
+    let result = roundTrip(err);
+    expect(result.message).toBe("all-bad");
+    expect("a" in result).toBe(false);
+    expect("b" in result).toBe(false);
+  })
+})
 
 // =======================================================================================
 
@@ -657,6 +862,155 @@ describe("basic rpc", () => {
     await using harness = new TestHarness(new TestTarget());
     let stub = harness.stub;
     await expect(() => stub.throwError()).rejects.toThrow(new RangeError("test error"));
+  });
+
+  it("preserves own properties on thrown errors over RPC", async () => {
+    class RichTarget extends RpcTarget {
+      throwRich() {
+        let err = new RangeError("rich") as any;
+        err.code = "E_RICH";
+        err.details = { reason: "because", count: 7 };
+        err.when = new Date(1234);
+        throw err;
+      }
+    }
+    await using harness = new TestHarness(new RichTarget());
+    let stub = harness.stub as any;
+
+    let caught: any;
+    try {
+      await stub.throwRich();
+    } catch (e) {
+      caught = e;
+    }
+
+    expect(caught).toBeInstanceOf(RangeError);
+    expect(caught.message).toBe("rich");
+    expect(caught.code).toBe("E_RICH");
+    expect(caught.details).toStrictEqual({ reason: "because", count: 7 });
+    expect(caught.when).toStrictEqual(new Date(1234));
+  });
+
+  it("preserves Error.cause on thrown errors over RPC", async () => {
+    class CauseTarget extends RpcTarget {
+      throwWithCause() {
+        throw new Error("outer", { cause: new TypeError("inner") });
+      }
+    }
+    await using harness = new TestHarness(new CauseTarget());
+    let stub = harness.stub as any;
+
+    let caught: any;
+    try {
+      await stub.throwWithCause();
+    } catch (e) {
+      caught = e;
+    }
+    expect(caught.message).toBe("outer");
+    expect(caught.cause).toBeInstanceOf(TypeError);
+    expect(caught.cause.message).toBe("inner");
+  });
+
+  it("round-trips heavyweight-but-supported types attached to errors", async () => {
+    class ReqErrTarget extends RpcTarget {
+      throwWithRequest() {
+        let err = new Error("with-request") as any;
+        err.request = new Request("http://example.com/", { method: "DELETE" });
+        throw err;
+      }
+    }
+    await using harness = new TestHarness(new ReqErrTarget());
+    let stub = harness.stub as any;
+
+    let caught: any;
+    try {
+      await stub.throwWithRequest();
+    } catch (e) {
+      caught = e;
+    }
+    expect(caught.message).toBe("with-request");
+    expect(caught.request).toBeInstanceOf(Request);
+    expect(caught.request.url).toBe("http://example.com/");
+    expect(caught.request.method).toBe("DELETE");
+  });
+
+  it("silently drops stub-valued error properties without leaking capabilities", async () => {
+    class CounterFactory extends RpcTarget {
+      throwWithStub() {
+        let err = new Error("with-stub") as any;
+        // Attach a stub to the error. There's no sensible lifetime for this capability, so
+        // it must be dropped on the wire rather than leaked to the importer.
+        err.counter = new RpcStub(new Counter(10));
+        err.code = "E_STUB";
+        throw err;
+      }
+    }
+    await using harness = new TestHarness(new CounterFactory());
+    let stub = harness.stub as any;
+
+    let caught: any;
+    try {
+      await stub.throwWithStub();
+    } catch (e) {
+      caught = e;
+    }
+    expect(caught.message).toBe("with-stub");
+    expect(caught.code).toBe("E_STUB");
+    expect("counter" in caught).toBe(false);
+    // The harness's checkAllDisposed() in asyncDispose verifies no exports/imports leaked.
+  });
+
+  it("drops the whole error property when a stub is nested inside an unserializable value", async () => {
+    // Regression: when an Error is serialized inside a successful payload (source is set),
+    // a property whose value contains both a stub and an unserializable sibling must drop
+    // the entire property atomically. Previously the stub would be exported on the way down
+    // before the unserializable sibling triggered the failure, leaking a capability.
+    class MixedFactory extends RpcTarget {
+      makeError() {
+        let err = new Error("with-mixed") as any;
+        err.mixed = { counter: new RpcStub(new Counter(10)), bad: Object.create(null) };
+        err.code = "E_MIXED";
+        return { wrapped: err };
+      }
+    }
+    await using harness = new TestHarness(new MixedFactory());
+    let stub = harness.stub as any;
+
+    let result = await stub.makeError();
+    expect(result.wrapped).toBeInstanceOf(Error);
+    expect(result.wrapped.message).toBe("with-mixed");
+    expect(result.wrapped.code).toBe("E_MIXED");
+    expect("mixed" in result.wrapped).toBe(false);
+    // checkAllDisposed() in asyncDispose verifies no stub leaked through the failed prop.
+  });
+
+  it("drops the whole error property when a ReadableStream is nested inside an unserializable value", async () => {
+    // Regression: ReadableStream side-effects (createPipe + pump start) must not fire if the
+    // surrounding property will ultimately be dropped. A simple try/catch + unexport rollback
+    // can't undo a started pipe, which is why we pre-scan instead.
+    class StreamFactory extends RpcTarget {
+      makeError() {
+        let stream = new ReadableStream({
+          start(controller) {
+            controller.enqueue("hello");
+            controller.close();
+          }
+        });
+        let err = new Error("with-stream") as any;
+        err.mixed = { stream, bad: Object.create(null) };
+        err.code = "E_STREAM";
+        return { wrapped: err };
+      }
+    }
+    await using harness = new TestHarness(new StreamFactory());
+    let stub = harness.stub as any;
+
+    let result = await stub.makeError();
+    expect(result.wrapped).toBeInstanceOf(Error);
+    expect(result.wrapped.message).toBe("with-stream");
+    expect(result.wrapped.code).toBe("E_STREAM");
+    expect("mixed" in result.wrapped).toBe(false);
+    // checkAllDisposed() in asyncDispose verifies no pipe leaked through the failed prop.
   });
 
   it("supports .then(), .catch(), and .finally() on RPC promises", async () => {
@@ -1463,6 +1817,68 @@ describe("error serialization", () => {
         return "caught";
       });
     expect(result).toBe("caught");
+  });
+
+  it("sends own properties from the rewritten error, not the original", async () => {
+    class ErrorTarget extends RpcTarget {
+      throwError() {
+        let err = new Error("original") as any;
+        err.code = "E_ORIGINAL";
+        throw err;
+      }
+    }
+    await using harness = new TestHarness(new ErrorTarget(), {
+      onSendError: _error => {
+        let rewritten = new TypeError("rewritten") as Error & Record<string, unknown>;
+        rewritten.code = "E_REWRITTEN";
+        return rewritten;
+      }
+    });
+    let stub = harness.stub as any;
+
+    let caught: unknown;
+    try {
+      await stub.throwError();
+    } catch (e) {
+      caught = e;
+    }
+
+    if (!(caught instanceof Error)) throw new Error("invariant");
+    expect(caught).toBeInstanceOf(TypeError);
+    expect(caught.message).toBe("rewritten");
+    expect((caught as Error & Record<string, unknown>).code).toBe("E_REWRITTEN");
+  });
+
+  it("respects in-place mutation by onSendError to scrub heavy properties", async () => {
+    class ErrorTarget extends RpcTarget {
+      throwError() {
+        let err = new Error("with-secret") as Error & Record<string, unknown>;
+        err.code = "E_OK";
+        err.secret = "super-sensitive-data";
+        throw err;
+      }
+    }
+    await using harness = new TestHarness(new ErrorTarget(), {
+      onSendError: error => {
+        // Returning the same error after mutating it is a documented escape hatch for
+        // scrubbing fields the caller doesn't want to send.
+        delete (error as any).secret;
+        return error;
+      }
+    });
+    let stub = harness.stub;
+
+    let caught: unknown;
+    try {
+      await stub.throwError();
+    } catch (e) {
+      caught = e;
+    }
+
+    if (!(caught instanceof Error)) throw new Error("invariant");
+    expect(caught.message).toBe("with-secret");
+    expect((caught as Error & Record<string, unknown>).code).toBe("E_OK");
+    expect("secret" in caught).toBe(false);
   });
 });
 

--- a/__tests__/index.test.ts
+++ b/__tests__/index.test.ts
@@ -984,35 +984,6 @@ describe("basic rpc", () => {
     // checkAllDisposed() in asyncDispose verifies no stub leaked through the failed prop.
   });
 
-  it("drops the whole error property when a ReadableStream is nested inside an unserializable value", async () => {
-    // Regression: ReadableStream side-effects (createPipe + pump start) must not fire if the
-    // surrounding property will ultimately be dropped. A simple try/catch + unexport rollback
-    // can't undo a started pipe, which is why we pre-scan instead.
-    class StreamFactory extends RpcTarget {
-      makeError() {
-        let stream = new ReadableStream({
-          start(controller) {
-            controller.enqueue("hello");
-            controller.close();
-          }
-        });
-        let err = new Error("with-stream") as any;
-        err.mixed = { stream, bad: Object.create(null) };
-        err.code = "E_STREAM";
-        return { wrapped: err };
-      }
-    }
-    await using harness = new TestHarness(new StreamFactory());
-    let stub = harness.stub as any;
-
-    let result = await stub.makeError();
-    expect(result.wrapped).toBeInstanceOf(Error);
-    expect(result.wrapped.message).toBe("with-stream");
-    expect(result.wrapped.code).toBe("E_STREAM");
-    expect("mixed" in result.wrapped).toBe(false);
-    // checkAllDisposed() in asyncDispose verifies no pipe leaked through the failed prop.
-  });
-
   it("supports .then(), .catch(), and .finally() on RPC promises", async () => {
     await using harness = new TestHarness(new TestTarget());
     let stub = harness.stub;

--- a/protocol.md
+++ b/protocol.md
@@ -180,11 +180,13 @@ A bigint value, represented as a decimal string.
 
 A JavaScript `Date` value. The number represents milliseconds since the Unix epoch.
 
-`["error", type, message, stack?]`
+`["error", type, message, stack?, props?]`
 
 A JavaScript `Error` value. `type` is the name of the specific well-known `Error` subclass, e.g. "TypeError". `message` is a string containing the error message. `stack` may optionally contain the stack trace, though by default stacks will be redacted for security reasons.
 
-_TODO: We should extend this to encode own properties that have been added to the error._
+`props` is an optional fifth element carrying any extra data attached to the error. It is a JSON object whose keys are the error's own enumerable properties (plus the standard non-enumerable `cause` slot, and `errors` for `AggregateError`), and whose values are themselves valid expressions of this protocol round-trip naturally. Property values that cannot be represented are silently dropped from `props`; the error itself always reaches the receiver.
+
+When `props` is present, `stack` is normalised to `null` if absent so that positional indexing for `props` is unambiguous. When there are no extras, the legacy 3- or 4-element form is emitted unchanged.
 
 `["headers", pairs]`
 

--- a/src/serialize.ts
+++ b/src/serialize.ts
@@ -96,6 +96,76 @@ export class Devaluator {
     }
   }
 
+  // Returns false on exactly the conditions under which `devaluateImpl` would throw. Must
+  // be kept in sync with `devaluateImpl`'s dispatch.
+  private canDevaluate(value: unknown, depth: number): boolean {
+    if (depth >= 64) return false;
+
+    let kind = typeForRpc(value);
+    switch (kind) {
+      case "unsupported":
+        return false;
+
+      case "primitive":
+      case "bigint":
+      case "date":
+      case "bytes":
+      case "headers":
+      case "undefined":
+        return true;
+
+      case "object": {
+        let object = <Record<string, unknown>>value;
+        for (let key in object) {
+          if (!this.canDevaluate(object[key], depth + 1)) return false;
+        }
+        return true;
+      }
+
+      case "array": {
+        let array = <Array<unknown>>value;
+        for (let i = 0; i < array.length; i++) {
+          if (!this.canDevaluate(array[i], depth + 1)) return false;
+        }
+        return true;
+      }
+
+      case "request": {
+        let req = <Request>value;
+        if (req.body) {
+          if (!this.canDevaluate(req.body, depth + 1)) return false;
+        }
+        return true;
+      }
+
+      case "response": {
+        let resp = <Response>value;
+        if ((<any>resp).webSocket) return false;
+        return this.canDevaluate(resp.body, depth + 1);
+      }
+
+      case "error":
+        // The error case in devaluateImpl catches per-property failures itself, so it never
+        // throws.
+        return true;
+
+      case "stub":
+      case "rpc-promise":
+      case "function":
+      case "rpc-target":
+      case "rpc-thenable":
+      case "writable":
+      case "readable":
+      case "blob":
+        // These cases throw if there's no `RpcPayload` source to serialize against.
+        return !!this.source;
+
+      default:
+        kind satisfies never;
+        return false;
+    }
+  }
+
   private exports?: Array<ExportId>;
 
   private devaluateImpl(value: unknown, parent: object | undefined, depth: number): unknown {
@@ -325,16 +395,46 @@ export class Devaluator {
 
         // TODO:
         // - Determine type by checking prototype rather than `name`, which can be overridden?
-        // - Serialize cause / suppressed error / etc.
-        // - Serialize added properties.
 
         let rewritten = this.exporter.onSendError(e);
         if (rewritten) {
           e = rewritten;
         }
 
-        let result = ["error", e.name, e.message];
-        if (rewritten && rewritten.stack) {
+        // Capture own enumerable properties plus the standard non-enumerable slots `cause`
+        // and (for AggregateError) `errors`. Each value is checked to ensure it will
+        // serialize before being included. Values that fail to serialize are dropped.
+        // The error itself must always make it through; use `onSendError` to scrub
+        // heavy or sensitive fields.
+        let anyE = <any>e;
+        let props: Record<string, unknown> | undefined;
+        let captureProp = (key: string, val: unknown) => {
+          if (!this.canDevaluate(val, depth + 1)) return;
+          let encoded = this.devaluateImpl(val, e, depth + 1);
+          if (!props) props = {};
+          props[key] = encoded;
+        };
+        for (let key of Object.keys(e)) {
+          if (key === "name" || key === "message" || key === "stack") continue;
+          captureProp(key, anyE[key]);
+        }
+        // `cause` is normally non-enumerable, so Object.keys() misses it.
+        if ("cause" in e) {
+          captureProp("cause", anyE.cause);
+        }
+        if (e instanceof AggregateError) {
+          captureProp("errors", e.errors);
+        }
+
+        // Backwards-compat: only emit the new tail elements when there's something to add.
+        // Errors with no extras serialize to the legacy 3- or 4-element form, byte-identical
+        // to what previous versions produced.
+        let result: unknown[] = ["error", e.name, e.message];
+        if (props) {
+          // Normalize the stack slot to null so `props` is always at index 4.
+          result.push(rewritten && rewritten.stack ? rewritten.stack : null);
+          result.push(props);
+        } else if (rewritten && rewritten.stack) {
           result.push(rewritten.stack);
         }
         return result;
@@ -566,9 +666,25 @@ export class Evaluator {
         case "error":
           if (value.length >= 3 && typeof value[1] === "string" && typeof value[2] === "string") {
             let cls = ERROR_TYPES[value[1]] || Error;
-            let result = new cls(value[2]);
+            // AggregateError's constructor takes (errors, message); we pass an empty array
+            // and patch `errors` from the props bag below.
+            let result = cls === AggregateError ? new cls([], value[2]) : new cls(value[2]);
             if (typeof value[3] === "string") {
               result.stack = value[3];
+            }
+            // Optional 5th element: own properties bag. Unknown keys are assigned as own
+            // enumerable properties so the receiver sees what the sender attached.
+            if (value.length >= 5) {
+              let props = value[4];
+              if (!props || typeof props !== "object" || Array.isArray(props)) {
+                break;  // malformed; fall through to the "unknown special value" throw
+              }
+              let anyResult = <any>result;
+              let propsObj = <Record<string, unknown>>props;
+              for (let key of Object.keys(propsObj)) {
+                if (key === "name" || key === "message" || key === "stack") continue;
+                anyResult[key] = this.evaluateImpl(propsObj[key], result, key);
+              }
             }
             return result;
           }

--- a/src/serialize.ts
+++ b/src/serialize.ts
@@ -92,77 +92,10 @@ export class Devaluator {
           // probably a side effect of the original error, ignore it
         }
       }
+      // TODO: This rollback only releases exports. Pipes created via `createPipe` (for
+      // ReadableStreams, Blobs, and the Firefox request-body fallback) have already sent a
+      // ["pipe"] frame and started pumping.
       throw err;
-    }
-  }
-
-  // Returns false on exactly the conditions under which `devaluateImpl` would throw. Must
-  // be kept in sync with `devaluateImpl`'s dispatch.
-  private canDevaluate(value: unknown, depth: number): boolean {
-    if (depth >= 64) return false;
-
-    let kind = typeForRpc(value);
-    switch (kind) {
-      case "unsupported":
-        return false;
-
-      case "primitive":
-      case "bigint":
-      case "date":
-      case "bytes":
-      case "headers":
-      case "undefined":
-        return true;
-
-      case "object": {
-        let object = <Record<string, unknown>>value;
-        for (let key in object) {
-          if (!this.canDevaluate(object[key], depth + 1)) return false;
-        }
-        return true;
-      }
-
-      case "array": {
-        let array = <Array<unknown>>value;
-        for (let i = 0; i < array.length; i++) {
-          if (!this.canDevaluate(array[i], depth + 1)) return false;
-        }
-        return true;
-      }
-
-      case "request": {
-        let req = <Request>value;
-        if (req.body) {
-          if (!this.canDevaluate(req.body, depth + 1)) return false;
-        }
-        return true;
-      }
-
-      case "response": {
-        let resp = <Response>value;
-        if ((<any>resp).webSocket) return false;
-        return this.canDevaluate(resp.body, depth + 1);
-      }
-
-      case "error":
-        // The error case in devaluateImpl catches per-property failures itself, so it never
-        // throws.
-        return true;
-
-      case "stub":
-      case "rpc-promise":
-      case "function":
-      case "rpc-target":
-      case "rpc-thenable":
-      case "writable":
-      case "readable":
-      case "blob":
-        // These cases throw if there's no `RpcPayload` source to serialize against.
-        return !!this.source;
-
-      default:
-        kind satisfies never;
-        return false;
     }
   }
 
@@ -402,17 +335,38 @@ export class Devaluator {
         }
 
         // Capture own enumerable properties plus the standard non-enumerable slots `cause`
-        // and (for AggregateError) `errors`. Each value is checked to ensure it will
-        // serialize before being included. Values that fail to serialize are dropped.
-        // The error itself must always make it through; use `onSendError` to scrub
-        // heavy or sensitive fields.
+        // and (for AggregateError) `errors`. Each value is run through devaluateImpl so any
+        // supported type round-trips. If a property's value can't be serialized, drop the
+        // property: the error itself must always make it through. Use `onSendError` to scrub
+        // heavy or sensitive fields explicitly.
+        //
+        // On per-property failure we roll back any exports the partial walk produced by
+        // splicing them off `this.exports` and unexporting them.
+        //
+        // TODO: this can't roll back pipes created by `createPipe` (ReadableStream, Blob,
+        // Firefox request-body); the `["pipe"]` frame and pump have already started, with
+        // no inverse on the `Exporter` interface, so they leak until session shutdown.
+        // Same caveat as the rollback in the static `devaluate` method above.
         let anyE = <any>e;
         let props: Record<string, unknown> | undefined;
         let captureProp = (key: string, val: unknown) => {
-          if (!this.canDevaluate(val, depth + 1)) return;
-          let encoded = this.devaluateImpl(val, e, depth + 1);
-          if (!props) props = {};
-          props[key] = encoded;
+          let exportsBefore = this.exports?.length ?? 0;
+          try {
+            let encoded = this.devaluateImpl(val, e, depth + 1);
+            if (!props) props = {};
+            props[key] = encoded;
+          } catch (err) {
+            // Drop this property; the error itself still propagates. Roll back any exports
+            // the partial walk produced.
+            if (this.exports && this.exports.length > exportsBefore) {
+              let tail = this.exports.splice(exportsBefore);
+              try {
+                this.exporter.unexport(tail);
+              } catch (err2) {
+                // probably a side effect of the original error, ignore it
+              }
+            }
+          }
         };
         for (let key of Object.keys(e)) {
           if (key === "name" || key === "message" || key === "stack") continue;


### PR DESCRIPTION
Closes #87.

Today the wire format for `Error` only carries `name`, `message`, and (optionally) `stack`. Anything a user attaches to the error — `code`, `details`, a `cause`, the inner errors of an `AggregateError` — is lost the moment the error crosses an RPC boundary.

This PR extends the `error` expression with an optional fifth element, `props`. This uses the same serialization/deserialization as any other object.

`Error.cause` and `AggregateError.errors` are normally non-enumerable, so they are picked up explicitly by the encoder. On the receive side, the decoder constructs the error as before and then assigns each entry from `props` as an own enumerable property on the result.

```ts
let err = new Error("rate limited");
err.code = "E_LIMIT";
err.retryAfter = 30;
throw err;
// receiver sees: err.code === "E_LIMIT", err.retryAfter === 30
```

Properties that cannot be fully serialized are dropped.

Tests have been added to verify the serialization/deserialization of various different error cases and failure modes. There may be too many, happy to remove any if needed.

The `error` expression in protocol.md now documents the optional `props` element, the lossy-fallback semantics.
