### PR TITLE
Fix memory leak from long-lived cancellation promise

### DIFF
--- a/.changeset/fair-rules-smoke.md
+++ b/.changeset/fair-rules-smoke.md
@@ -1,0 +1,5 @@
+---
+"capnweb": patch
+---
+
+Fix memory leak that kept all messages received in a session pinned in memory until the session ended, due to surprising implementation details of JavaScript Promises.

--- a/src/rpc.ts
+++ b/src/rpc.ts
@@ -323,7 +323,7 @@ class RpcSessionImpl implements Importer, Exporter {
   private reverseExports: Map<StubHook, ExportId> = new Map();
   private imports: Array<ImportTableEntry> = [];
   private abortReason?: any;
-  private cancelReadLoop: (error: any) => void;
+  private cancelReadLoop?: (error: any) => void;
 
   // We assign positive numbers to imports we initiate, and negative numbers to exports we
   // initiate. So the next import ID is just `imports.length`, but the next export ID needs
@@ -348,11 +348,7 @@ class RpcSessionImpl implements Importer, Exporter {
     // Import zero is the other side's bootstrap object.
     this.imports.push(new ImportTableEntry(this, 0, false));
 
-    let rejectFunc: (error: any) => void;;
-    let abortPromise = new Promise<never>((resolve, reject) => { rejectFunc = reject; });
-    this.cancelReadLoop = rejectFunc!;
-
-    this.readLoop(abortPromise).catch(err => this.abort(err));
+    this.readLoop().catch(err => this.abort(err));
   }
 
   // Should only be called once immediately after construction.
@@ -684,7 +680,8 @@ class RpcSessionImpl implements Importer, Exporter {
     // Don't double-abort.
     if (this.abortReason !== undefined) return;
 
-    this.cancelReadLoop(error);
+    this.cancelReadLoop?.(error);
+    this.cancelReadLoop = undefined;
 
     if (trySendAbortMessage) {
       try {
@@ -734,9 +731,22 @@ class RpcSessionImpl implements Importer, Exporter {
     }
   }
 
-  private async readLoop(abortPromise: Promise<never>) {
+  private async readLoop() {
     while (!this.abortReason) {
-      let msg = JSON.parse(await Promise.race([this.transport.receive(), abortPromise]));
+      // Each receive needs its own abort promise so Promise.race() doesn't keep old reads.
+      let readCanceled = Promise.withResolvers<never>();
+      this.cancelReadLoop = readCanceled.reject;
+
+      let msgText: string;
+      try {
+        msgText = await Promise.race([this.transport.receive(), readCanceled.promise]);
+      } finally {
+        if (this.cancelReadLoop === readCanceled.reject) {
+          this.cancelReadLoop = undefined;
+        }
+      }
+
+      let msg = JSON.parse(msgText);
       if (this.abortReason) break;  // check again before processing
 
       if (msg instanceof Array) {


### PR DESCRIPTION
_This fix is actually #154 from @VastBlast, but I removed the middle commit and squashed the other two. (The middle commit of #154 was addressing an unrelated problem and is more controversial -- see my comments there.)_

This fixes a memory leak in long sessions. It turns out that due to the implementation details of JavaScript promises:

* If you call `Promise.race([a, b])` many times and one of the promises (`b`, let's say) is always the same promise, then each call will add a new "reaction" callback to `b`, which never gets removed until `b` actually fires. These reactions all become no-ops assuming `a` resolves first, but they still stick around.
* Worse, the reaction itself holds a reference to the `Promise` representing the result of the race, and that `Promise` object itself, once resolved, holds a reference to its resolution. Hence, all of the resolutions of the different `a` promises end up reachable from `b` and so cannot be GC'd.

The net result for Cap'n Web is: All of the messages received on a WebSocket session remained stuck in-memory until the session closed. Whoops.

This is all very silly. One would expect that a reactor callback pointing to an already-resolved promise should simply "null itself out" so that the GC can see that the resolution is not reachable through it. But the problem seems to have arisen because:
* The language spec does not specify how GC should work, so does not concern itself with anything to do with making GC work better.
* Hence, the spec does not specify that resolver functions should "null themselves out" -- though it also doesn't explicitly say they can't.
* Implementations seem to have implemented the spec to the letter, without any additional thought about GC.

Ironically, despite this problem existing for a decade already, it seems there is a recent push to fix it, at least in V8: https://chromium-review.googlesource.com/c/v8/v8/+/7646250

But this won't fix the `Promise.race` leak (first point above), so we should still land this fix to Cap'n WEb.