### PR TITLE
docs: add info about Blob serialization to protocol.md

### DIFF
--- a/protocol.md
+++ b/protocol.md
@@ -172,6 +172,10 @@ The values Infinity, -Infinity, and NaN.
 
 A `Uint8Array`, represented as a base64-encoded string.
 
+`["blob", type, readableExpression]`
+
+A `Blob` value. `type` is the MIME type string (`blob.type`), which may be an empty string. `readableExpression` is an expression that evaluates to a `ReadableStream` carrying the blob's bytes; in practice, the encoder always uses a `["readable", importId]` expression backed by a pipe. Because reading a `Blob`'s bytes is inherently asynchronous, the pipe path is always used — there is no inline fast path even for small blobs. The receiver must collect all chunks from the stream before delivering the value to application code.
+
 `["bigint", decimal]`
 
 A bigint value, represented as a decimal string.


### PR DESCRIPTION
Fixes #170, based on the implementation of #155 