### PR TITLE
Add WebSocket serialization support

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,6 +205,14 @@ The following types can be passed over RPC (in arguments or return values), and 
 * `ReadableStream` and `WritableStream`, with automatic flow control.
 * `Headers`, `Request`, and `Response` from the Fetch API.
 
+Live `WebSocket` objects, including a Cloudflare Workers `Response` with a `.webSocket`
+property, can also be passed over RPC. Unlike the types above, a WebSocket is passed by
+reference: the receiver gets a WebSocket-like bridge connected to the original socket. The bridge
+supports `send()`, `close()`, `accept()`, `readyState`, and `message` / `close` / `error` event
+listeners, but it is not a full platform WebSocket object. Close or dispose it when done so the
+remote socket can be released. WebSocket tunneling carries frames over the RPC session and does
+not add `ReadableStream`-style flow control.
+
 The following types are not supported as of this writing, but may be added in the future:
 * `Map` and `Set`
 * `ArrayBuffer` and typed arrays other than `Uint8Array`

--- a/__tests__/test-server.ts
+++ b/__tests__/test-server.ts
@@ -51,7 +51,10 @@ export async function setup(project: TestProject) {
   })
 
   // Listen on an ephemeral port for testing purposes.
-  httpServer.listen(0);
+  await new Promise<void>((resolve, reject) => {
+    httpServer!.once("error", reject);
+    httpServer!.listen(0, "127.0.0.1", resolve);
+  });
   let addr = httpServer.address() as AddressInfo;
 
   // Provide the server address to tests.

--- a/__tests__/websocket-serialization.test.ts
+++ b/__tests__/websocket-serialization.test.ts
@@ -1,0 +1,177 @@
+// Copyright (c) 2025 Cloudflare, Inc.
+// Licensed under the MIT license found in the LICENSE.txt file or at:
+//     https://opensource.org/license/mit
+
+import { expect, it, describe } from "vitest";
+import type { AddressInfo } from "node:net";
+import { WebSocket as WsWebSocket, WebSocketServer } from "ws";
+import { newWebSocketRpcSession, RpcTarget } from "../src/index.js";
+
+function listenWebSocket(server: WebSocketServer): Promise<number> {
+  return new Promise((resolve, reject) => {
+    server.on("error", reject);
+    server.on("listening", () => {
+      resolve((server.address() as AddressInfo).port);
+    });
+  });
+}
+
+function closeWebSocket(server: WebSocketServer): Promise<void> {
+  return new Promise(resolve => {
+    for (let client of server.clients) client.terminate();
+    server.close(() => resolve());
+  });
+}
+
+function waitOpen(socket: WsWebSocket): Promise<void> {
+  if (socket.readyState === WsWebSocket.OPEN) return Promise.resolve();
+
+  return new Promise((resolve, reject) => {
+    socket.addEventListener("open", () => resolve(), { once: true });
+    socket.addEventListener("error", () => reject(new Error("WebSocket failed to open")), {
+      once: true,
+    });
+  });
+}
+
+function withTimeout<T>(promise: Promise<T>, ms = 5000): Promise<T> {
+  let timer: ReturnType<typeof setTimeout>;
+  let timeout = new Promise<never>((_, reject) => {
+    timer = setTimeout(() => reject(new Error("Timed out waiting for WebSocket message")), ms);
+  });
+
+  return Promise.race([promise, timeout]).finally(() => clearTimeout(timer));
+}
+
+function nextMessage(socket: { addEventListener(type: "message", listener: (event: any) => void, options?: any): void })
+    : Promise<string | Uint8Array> {
+  return new Promise(resolve => {
+    socket.addEventListener("message", event => resolve(event.data), { once: true });
+  });
+}
+
+function nextClose(socket: { addEventListener(type: "close", listener: (event: any) => void, options?: any): void })
+    : Promise<{ code: number, reason: string }> {
+  return new Promise(resolve => {
+    socket.addEventListener("close", event => {
+      resolve({ code: event.code, reason: event.reason });
+    }, { once: true });
+  });
+}
+
+function responseWithWebSocket(socket: WebSocket): Response {
+  let response = new Response(null, { status: 204 });
+  Object.defineProperty(response, "webSocket", { value: socket });
+  return response;
+}
+
+describe("WebSocket serialization", () => {
+  it("can pass a live WebSocket through an RPC result", async () => {
+    let echoServer = new WebSocketServer({ host: "127.0.0.1", port: 0 });
+    echoServer.on("connection", socket => {
+      socket.on("message", (data, isBinary) => socket.send(data, { binary: isBinary }));
+    });
+    let echoPort = await listenWebSocket(echoServer);
+
+    class Api extends RpcTarget {
+      async open() {
+        let socket = new WsWebSocket(`ws://127.0.0.1:${echoPort}`);
+        await waitOpen(socket);
+        return socket;
+      }
+
+      async openResponse() {
+        let socket = new WsWebSocket(`ws://127.0.0.1:${echoPort}`);
+        await waitOpen(socket);
+        return responseWithWebSocket(socket as any);
+      }
+    }
+
+    let rpcServer = new WebSocketServer({ host: "127.0.0.1", port: 0 });
+    rpcServer.on("connection", socket => {
+      newWebSocketRpcSession(socket as any, new Api());
+    });
+    let rpcPort = await listenWebSocket(rpcServer);
+
+    let api: any = newWebSocketRpcSession(new WsWebSocket(`ws://127.0.0.1:${rpcPort}`) as any);
+    try {
+      let socket: any = await api.open();
+      let message = nextMessage(socket);
+      socket.send("hello over a bridged socket");
+
+      expect(await withTimeout(message)).toBe("hello over a bridged socket");
+
+      let binaryMessage = nextMessage(socket);
+      socket.send(new Uint8Array([1, 2, 3]).buffer);
+      let bytes = await withTimeout(binaryMessage);
+      expect(typeof bytes).not.toBe("string");
+      expect(Array.from(bytes as Uint8Array)).toEqual([1, 2, 3]);
+
+      let close = nextClose(socket);
+      socket.close(1000, "done");
+      expect(await withTimeout(close)).toEqual({ code: 1000, reason: "done" });
+      socket.close();
+
+      let response: any = await api.openResponse();
+      expect(response.status).toBe(204);
+      expect(response.webSocket).toBeTruthy();
+
+      let responseMessage = nextMessage(response.webSocket);
+      response.webSocket.send("hello through Response.webSocket");
+      expect(await withTimeout(responseMessage)).toBe("hello through Response.webSocket");
+      response.webSocket.close();
+    } finally {
+      await closeWebSocket(rpcServer);
+      await closeWebSocket(echoServer);
+    }
+  }, 10_000);
+
+  it("can run Cap'n Web over a WebSocket tunneled through Cap'n Web", async () => {
+    class Processor extends RpcTarget {
+      square(value: number) { return value * value; }
+      greet(name: string) { return `hello ${name}`; }
+    }
+
+    let processorServer = new WebSocketServer({ host: "127.0.0.1", port: 0 });
+    processorServer.on("connection", socket => {
+      newWebSocketRpcSession(socket as any, new Processor());
+    });
+    let processorPort = await listenWebSocket(processorServer);
+
+    class TunnelTarget extends RpcTarget {
+      async fetch(request: Request): Promise<Response> {
+        if (request.headers.get("Upgrade")?.toLowerCase() !== "websocket") {
+          return new Response("Expected a WebSocket upgrade.", { status: 426 });
+        }
+
+        let socket = new WsWebSocket(`ws://127.0.0.1:${processorPort}`);
+        await waitOpen(socket);
+
+        let response = new Response(null);
+        Object.defineProperty(response, "webSocket", { value: socket });
+        return response;
+      }
+    }
+
+    let tunnelServer = new WebSocketServer({ host: "127.0.0.1", port: 0 });
+    tunnelServer.on("connection", socket => {
+      newWebSocketRpcSession(socket as any, new TunnelTarget());
+    });
+    let tunnelPort = await listenWebSocket(tunnelServer);
+
+    let tunnelApi: any =
+        newWebSocketRpcSession(new WsWebSocket(`ws://127.0.0.1:${tunnelPort}`) as any);
+    let response: any = await tunnelApi.fetch(new Request("https://captun.test/processor", {
+      headers: { Upgrade: "websocket" },
+    }));
+
+    let processor: any = newWebSocketRpcSession(response.webSocket);
+    try {
+      expect(await processor.square(7)).toBe(49);
+      expect(await processor.greet("captun")).toBe("hello captun");
+    } finally {
+      await closeWebSocket(tunnelServer);
+      await closeWebSocket(processorServer);
+    }
+  }, 10_000);
+});

--- a/protocol.md
+++ b/protocol.md
@@ -203,10 +203,15 @@ A `Request` object from the Fetch API. `url` and `init` are the parameters to pa
 At this time, `init.signal` is not supported and must not be sent, though that will change when `AbortSignal` gains support for serialization.
 
 `["response", body, init]`
+`["response", body, init, webSocketExpression]`
 
 A `Response` object from the Fetch API. `body` and `init` are the parameters to pass to `Response`'s constructor to create the desired `Response` instance. `body` is an expression which must evaluate to `null`, a string, `UInt8Array`, or `ReadableStream`. `init.headers`, if present, must contain an array of pairs, suitable to pass to the constructor of `Headers`. Other properties of `init` must be plain values; they will not be evaluated as expressions before passing to the `Response` constructor.
 
-At this time, `init.webSocket` (a Cloudflare Workers extension) is not supported and must not be sent, though that may change if `WebSocket` gains support for serialization.
+The 4-element form represents a response with an attached WebSocket, as in the Cloudflare Workers `Response.webSocket` extension. `webSocketExpression` evaluates to a live WebSocket capability. The receiver reconstructs a `Response` with a non-standard `.webSocket` property; the presence of that property is the upgrade signal. Since standard `Response` constructors cannot represent 1xx statuses, senders omit `status` and `statusText` from `init` when a WebSocket-bearing response has a 1xx status.
+
+`["websocket", exportExpression]`
+
+A live WebSocket connection, represented as a capability rather than a value. `exportExpression` evaluates to an exported object that forwards `send()`, `close()`, and socket events. The receiver gets a WebSocket-like object suitable for sending frames, receiving `message` / `close` / `error` events, and passing to `newWebSocketRpcSession()`. WebSocket frames are delivered in order, but this bridge does not add stream-style flow control beyond the underlying socket and RPC transport.
 
 `["import", importId, propertyPath, callArguments]`
 `["pipeline", importId, propertyPath, callArguments]`

--- a/src/core.ts
+++ b/src/core.ts
@@ -39,7 +39,8 @@ export type PropertyPath = (string | number)[];
 
 type TypeForRpc = "unsupported" | "primitive" | "object" | "function" | "array" | "date" |
     "bigint" | "bytes" | "blob" | "stub" | "rpc-promise" | "rpc-target" | "rpc-thenable" |
-    "error" | "undefined" | "writable" | "readable" | "headers" | "request" | "response";
+    "error" | "undefined" | "writable" | "readable" | "headers" | "request" | "response" |
+    "websocket";
 
 const AsyncFunction = (async function () {}).constructor;
 
@@ -47,6 +48,19 @@ const AsyncFunction = (async function () {}).constructor;
 // to accept as "bytes". In browsers, this is undefined, which won't match any prototype.
 let BUFFER_PROTOTYPE: object | undefined =
     typeof Buffer !== "undefined" ? Buffer.prototype : undefined;
+
+function isWebSocketLike(value: object): boolean {
+  if (typeof WebSocket !== "undefined" && value instanceof WebSocket) {
+    return true;
+  }
+
+  let socket = value as any;
+  return typeof socket.send === "function" &&
+      typeof socket.close === "function" &&
+      typeof socket.addEventListener === "function" &&
+      (typeof socket.readyState === "number" || "binaryType" in socket || "protocol" in socket) &&
+      (socket.constructor?.name === "WebSocket" || "binaryType" in socket || "protocol" in socket);
+}
 
 export function typeForRpc(value: unknown): TypeForRpc {
   switch (typeof value) {
@@ -146,6 +160,13 @@ export function typeForRpc(value: unknown): TypeForRpc {
 
       if (value instanceof Error) {
         return "error";
+      }
+
+      // A live `WebSocket` (Workers' `WebSocketPair` ends, browsers/Node, or ws-compatible
+      // server sockets). Runtime constructors differ, so accept the standard EventTarget-shaped
+      // socket interface rather than requiring a single global constructor.
+      if (isWebSocketLike(value)) {
+        return "websocket";
       }
 
       return "unsupported";
@@ -805,11 +826,11 @@ export class RpcPayload {
   // return, so that we can make sure they are not disposed before the pipeline ends.
   //
   // This is initialized on first use.
-  private rpcTargets?: Map<RpcTarget | Function | WritableStream | ReadableStream, StubHook>;
+  private rpcTargets?: Map<object, StubHook>;
 
   // Get the StubHook representing the given RpcTarget found inside this payload.
   public getHookForRpcTarget(target: RpcTarget | Function, parent: object | undefined,
-                             dupStubs: boolean = true): StubHook {
+                             dupStubs: boolean = true, mapKey: object = target): StubHook {
     if (this.source === "params") {
       if (dupStubs) {
         // We aren't supposed to take ownership of stubs appearing in params -- we're supposed to
@@ -846,12 +867,12 @@ export class RpcPayload {
       // * If the target is not in the map, we just create it, but don't populate the map.
       // * If the target *is* in the map, we *remove* the hook from the map, and return it.
 
-      let hook = this.rpcTargets?.get(target);
+      let hook = this.rpcTargets?.get(mapKey);
       if (hook) {
         if (dupStubs) {
           return hook.dup();
         } else {
-          this.rpcTargets?.delete(target);
+          this.rpcTargets?.delete(mapKey);
           return hook;
         }
       } else {
@@ -860,7 +881,7 @@ export class RpcPayload {
           if (!this.rpcTargets) {
             this.rpcTargets = new Map;
           }
-          this.rpcTargets.set(target, hook);
+          this.rpcTargets.set(mapKey, hook);
           return hook.dup();
         } else {
           return hook;
@@ -1078,8 +1099,20 @@ export class RpcPayload {
         // Make an actual copy of the object, e.g. so the headers are copied.
         // Note that it would be incorrect to use clone() here since that would tee() the body
         // stream.
-        return new Response(resp.body, resp);
+        let result: any = new Response(resp.body, resp);
+        let webSocket = (<any>resp).webSocket;
+        if (webSocket) {
+          Object.defineProperty(result, "webSocket", {
+            value: webSocket,
+            configurable: true,
+          });
+        }
+        return result;
       }
+
+      case "websocket":
+        // A live connection is a reference type (like a stream); share it rather than copy.
+        return value;
 
       default:
         kind satisfies never;
@@ -1348,9 +1381,23 @@ export class RpcPayload {
         // The body may be a ReadableStream that has an associated hook in rpcTargets.
         let resp = <Response>value;
         if (resp.body) this.disposeImpl(resp.body, resp);
-        // TODO: When we support WebSocket, we may need to dispose response.webSocket here?
+        let cfResp = resp as any;
+        if (cfResp.webSocket) this.disposeImpl(cfResp.webSocket, resp);
         return;
       }
+
+      case "websocket":
+        {
+          let socket = <any>value;
+          let hook = this.rpcTargets?.get(socket);
+          if (hook) {
+            hook.dispose();
+            this.rpcTargets!.delete(socket);
+          } else {
+            try { socket.close(); } catch {}
+          }
+        }
+        return;
 
       case "writable": {
         let stream = <WritableStream>value;
@@ -1451,6 +1498,10 @@ export class RpcPayload {
 
       case "rpc-thenable":
         (<any>value).then((_: any) => {}, (_: any) => {});
+        return;
+
+      case "websocket":
+        // No promises attached; nothing to ignore.
         return;
 
       default:
@@ -1578,6 +1629,7 @@ function followPath(value: unknown, parent: object | undefined,
       case "headers":
       case "request":
       case "response":
+      case "websocket":
         // These have no properties that can be accessed remotely.
         value = undefined;
         break;

--- a/src/serialize.ts
+++ b/src/serialize.ts
@@ -3,6 +3,7 @@
 //     https://opensource.org/license/mit
 
 import { StubHook, RpcPayload, typeForRpc, RpcStub, RpcPromise, LocatedPromise, RpcTarget, unwrapStubAndPath, streamImpl, PromiseStubHook, PayloadStubHook } from "./core.js";
+import { WebSocketSource, BridgedWebSocket } from "./websocket-bridge.js";
 
 export type ImportId = number;
 export type ExportId = number;
@@ -301,11 +302,28 @@ export class Devaluator {
           init.encodeBody = cfResp.encodeBody;
         }
         if (cfResp.webSocket) {
-          // As of this writing, we don't support WebSocket, but we might someday.
-          throw new TypeError("Can't serialize a Response containing a webSocket.");
+          // Ferry the attached WebSocket as a capability over the same session (see
+          // websocket-bridge.ts). It rides along as a 4th wire element so the body/init encoding
+          // is unchanged for the common, socket-less case.
+          if (typeof init.status === "number" && init.status >= 100 && init.status < 200) {
+            delete init.status;
+            delete init.statusText;
+          }
+          let ws = this.devaluateImpl(cfResp.webSocket, resp, depth + 1);
+          return ["response", body, init, ws];
         }
 
         return ["response", body, init];
+      }
+
+      case "websocket": {
+        if (!this.source) {
+          throw new Error("Can't serialize a WebSocket in this context.");
+        }
+        // Export the live socket as a capability; the peer rebuilds a BridgedWebSocket from it.
+        let hook = this.source.getHookForRpcTarget(
+            <RpcTarget><any>new WebSocketSource(<WebSocket>value), parent, true, <object>value);
+        return ["websocket", this.devaluateHook("export", hook)];
       }
 
       case "blob": {
@@ -710,7 +728,8 @@ export class Evaluator {
         }
 
         case "response": {
-          if (value.length !== 3) break;
+          // 3 elements normally; a 4th carries an attached WebSocket capability.
+          if (value.length !== 3 && value.length !== 4) break;
 
           let body = this.evaluateImpl(value[1], parent, property);
           if (body === null ||
@@ -725,20 +744,30 @@ export class Evaluator {
           let init = value[2];
           if (typeof init !== "object" || init === null) break;
 
-          // Evaluate specific properties which are expected to contain non-trivial types.
-          if (init.webSocket) {
-            // `response.webSocket` is a Cloudflare Workers extension. Not (yet?) supported for
-            // serialization.
-            throw new TypeError("Can't deserialize a Response containing a webSocket.");
-          }
-
           // Type-check `headers` is an array because the constructor allows multiple
           // representations and we don't want to allow the others.
           if (init.headers && !(init.headers instanceof Array)) {
             throw new TypeError("Request headers must be serialized as an array of pairs.");
           }
 
+          if (value.length === 4) {
+            // The deserialized socket is a BridgedWebSocket, not a platform WebSocket, so the
+            // consumer is responsible for pumping frames between it and a socket it owns.
+            let webSocket = this.evaluateImpl(value[3], parent, property);
+            let result: any = new Response(body as BodyInit | null, init as ResponseInit);
+            Object.defineProperty(result, "webSocket", {
+              value: webSocket,
+              configurable: true,
+            });
+            return result;
+          }
+
           return new Response(body as BodyInit | null, init as ResponseInit);
+        }
+
+        case "websocket": {
+          if (value.length !== 2) break;
+          return new BridgedWebSocket(this.evaluateImpl(value[1], parent, property));
         }
 
         case "blob": {

--- a/src/websocket-bridge.ts
+++ b/src/websocket-bridge.ts
@@ -1,0 +1,181 @@
+// Copyright (c) 2025 Cloudflare, Inc.
+// Licensed under the MIT license found in the LICENSE.txt file or at:
+//     https://opensource.org/license/mit
+
+import { RpcTarget } from "./core.js";
+
+/** Inbound frame events delivered from the source socket to the bridged peer. */
+type WireEvent =
+  | { type: "message"; data: string | Uint8Array }
+  | { type: "close"; code: number; reason: string }
+  | { type: "error" };
+
+/** The subset of the platform `WebSocket` API we depend on. */
+interface WebSocketLike {
+  send(data: string | ArrayBufferLike | Uint8Array): void;
+  close(code?: number, reason?: string): void;
+  accept?(): void;
+  addEventListener(type: string, listener: (event: any) => void): void;
+  readyState?: number;
+  binaryType?: string;
+}
+
+function normalizeData(data: unknown): string | Uint8Array {
+  if (typeof data === "string") return data;
+  if (data instanceof Uint8Array) return data;
+  if (data instanceof ArrayBuffer) return new Uint8Array(data);
+  if (ArrayBuffer.isView(data)) {
+    let view = data as ArrayBufferView;
+    return new Uint8Array(view.buffer, view.byteOffset, view.byteLength);
+  }
+  return String(data);
+}
+
+export class WebSocketSource extends RpcTarget {
+  #socket: WebSocketLike;
+  #receiver?: (event: WireEvent) => void;
+  #backlog: WireEvent[] = [];
+  #closed = false;
+
+  constructor(socket: WebSocketLike) {
+    super();
+    this.#socket = socket;
+    try { socket.accept?.(); } catch { /* already accepted or not supported */ }
+    try { socket.binaryType = "arraybuffer"; } catch {}
+    socket.addEventListener("message", (e: any) =>
+      this.#emit({ type: "message", data: normalizeData(e.data) }));
+    socket.addEventListener("close", (e: any) =>
+      this.#emit({ type: "close", code: e?.code ?? 1005, reason: e?.reason ?? "" }));
+    socket.addEventListener("error", () => this.#emit({ type: "error" }));
+  }
+
+  start(receiver: (event: WireEvent) => void): void {
+    if (this.#receiver) throw new Error("WebSocket bridge already started.");
+    // Call params are implicitly disposed when the call returns, so retain a duplicate.
+    let retained = (receiver as any)?.dup ? (receiver as any).dup() : receiver;
+    this.#receiver = retained;
+    for (const event of this.#backlog) this.#sendToReceiver(retained, event);
+    this.#backlog = [];
+  }
+
+  send(data: string | Uint8Array): void {
+    this.#socket.send(data);
+  }
+
+  close(code?: number, reason?: string): void {
+    this.#socket.close(code, reason);
+  }
+
+  [Symbol.dispose](): void {
+    (this.#receiver as any)?.[Symbol.dispose]?.();
+    this.#receiver = undefined;
+    if (!this.#closed && this.#socket.readyState !== 3) {
+      try { this.#socket.close(); } catch {}
+    }
+  }
+
+  #emit(event: WireEvent): void {
+    if (event.type === "close") {
+      this.#closed = true;
+    }
+
+    if (this.#receiver) this.#sendToReceiver(this.#receiver, event);
+    else this.#backlog.push(event);
+  }
+
+  #sendToReceiver(receiver: (event: WireEvent) => void, event: WireEvent): void {
+    Promise.resolve(receiver(event)).catch(() => {});
+  }
+}
+
+type Listener = (event: any) => void;
+
+export class BridgedWebSocket {
+  static readonly CONNECTING = 0;
+  static readonly OPEN = 1;
+  static readonly CLOSING = 2;
+  static readonly CLOSED = 3;
+
+  #stub: any;
+  #readyState = BridgedWebSocket.OPEN;
+  #listeners: Record<string, Listener[]> = { message: [], close: [], error: [], open: [] };
+
+  onmessage: Listener | null = null;
+  onclose: Listener | null = null;
+  onerror: Listener | null = null;
+  onopen: Listener | null = null;
+
+  constructor(stub: any) {
+    // Retain the capability: a stub arriving as a call result is implicitly disposed shortly
+    // after that call settles, which would sever the bridge. dup() gives us an owned copy whose
+    // lifetime we control (released in close()).
+    this.#stub = stub?.dup ? stub.dup() : stub;
+    // Begin receiving inbound frames. The callback is invoked via RPC from the source side.
+    Promise.resolve(this.#stub.start((event: WireEvent) => this.#dispatch(event)))
+      .catch(err => this.#fire("error", { type: "error", error: err }));
+  }
+
+  get readyState(): number { return this.#readyState; }
+
+  /** No-op for Workers `WebSocket` API compatibility; the source side already accepted. */
+  accept(): void {}
+
+  send(data: string | ArrayBufferLike | ArrayBufferView): void {
+    this.#ignore(this.#stub.send(normalizeData(data)));
+  }
+
+  close(code?: number, reason?: string): void {
+    if (this.#readyState >= BridgedWebSocket.CLOSING) return;
+    this.#readyState = BridgedWebSocket.CLOSING;
+    this.#ignore(this.#stub.close(code, reason));
+  }
+
+  [Symbol.dispose](): void {
+    this.close();
+    this.#release();
+  }
+
+  addEventListener(type: string, listener: Listener): void {
+    (this.#listeners[type] ??= []).push(listener);
+  }
+
+  removeEventListener(type: string, listener: Listener): void {
+    const list = this.#listeners[type];
+    if (!list) return;
+    const i = list.indexOf(listener);
+    if (i >= 0) list.splice(i, 1);
+  }
+
+  #fire(type: string, event: any): void {
+    for (const listener of this.#listeners[type] ?? []) listener(event);
+    const handler = (this as any)["on" + type] as Listener | null;
+    if (handler) handler(event);
+  }
+
+  #ignore(result: any): void {
+    if (result?.then) {
+      result.then(() => {}, (err: any) => this.#fire("error", { type: "error", error: err }));
+    }
+  }
+
+  #release(): void {
+    this.#stub?.[Symbol.dispose]?.();
+    this.#stub = undefined;
+  }
+
+  #dispatch(event: WireEvent): void {
+    switch (event.type) {
+      case "message":
+        this.#fire("message", { type: "message", data: event.data });
+        break;
+      case "close":
+        this.#readyState = BridgedWebSocket.CLOSED;
+        this.#fire("close", { type: "close", code: event.code, reason: event.reason });
+        this.#release();
+        break;
+      case "error":
+        this.#fire("error", { type: "error" });
+        break;
+    }
+  }
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -17,7 +17,11 @@ export default defineConfig({
           name: 'node',
           // We throw flow-control test under Node only because it's testing straightforward
           // JavaScript -- no need to run it on every runtime.
-          include: ['__tests__/index.test.ts', '__tests__/flow-control.test.ts'],
+          include: [
+            '__tests__/index.test.ts',
+            '__tests__/flow-control.test.ts',
+            '__tests__/websocket-serialization.test.ts',
+          ],
           environment: 'node',
         },
       },


### PR DESCRIPTION
## What changed

Adds support for passing live WebSockets through Cap'n Web RPC messages by exporting the socket as a capability and reconstructing a bridged WebSocket-like object on the receiving side.

This also allows `Response` values carrying a `.webSocket` property to cross RPC boundaries. The presence of `.webSocket` is the upgrade signal; the code does not depend on status `101`.

## Why

This enables a Cap'n Web `fetch(request)` target to return a WebSocket-bearing `Response`, so callers can run WebSocket traffic, including another Cap'n Web WebSocket session, through an existing Cap'n Web tunnel.

## Scope notes

- Adds the `websocket` wire expression plus the 4-element `response` form to `protocol.md`.
- Adds a short README note describing WebSocket pass-by-reference semantics, bridge shape, and disposal expectations.
- Includes one focused Node test file covering direct WebSocket serialization, binary frames, close code/reason propagation, `Response.webSocket`, and Cap'n-Web-over-bridged-WebSocket.
- Kept the public quick-tunnel proof out of the default test suite because it depends on external network, `cloudflared`, and DNS propagation.
- The only general test infrastructure change binds the existing test server to `127.0.0.1`; this makes the existing WebKit browser HTTP/WebSocket tests reachable in the local full matrix.

## Review follow-ups applied

- Removed scratch/public-network test files from the PR.
- Avoided lockfile churn and unrelated test skips.
- Fixed bridge lifetime so `close()` preserves the retained receiver until the remote close event arrives.
- Made bridge startup one-shot to avoid leaking a replaced retained receiver.
- Preserved `Response.webSocket` on local `Response` copies.
- Normalized binary frame payloads and accepted ArrayBuffer / typed-array sends.
- Strip only invalid 1xx response status/statusText when serializing WebSocket-bearing responses.

## Validation

- `npx vitest run --project node __tests__/websocket-serialization.test.ts` - 2 passed
- `npm run test:types`
- `npm run build`
- `npm run test:bun` - 16 passed
- `npm test` - 817 passed
- Manual live public tunnel proof: `CAPNWEB_PUBLIC_TUNNEL=1 npx vitest run --project node __tests__/websocket-public-tunnel.test.ts` passed locally before removing the external-network test from the PR. It opened a real `trycloudflare.com` tunnel, connected via public WSS, received a WebSocket-bearing `Response`, and ran Cap'n Web over that bridged socket.