### PR TITLE
ci(cla): allowlist github-actions[bot] for changesets release PRs

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -26,5 +26,5 @@ jobs:
           path-to-document: 'https://www.cloudflare.com/cla/'
           # branch should not be protected
           branch: 'cla-signatures'
-          allowlist: dependabot[bot],workers-devprod
+          allowlist: dependabot[bot],workers-devprod,github-actions[bot]
           lock-pullrequest-aftermerge: false


### PR DESCRIPTION
## Why

The Changesets "Version Packages" PRs (e.g. #191) are opened with commits authored by `github-actions[bot]`. That account isn't in the CLA Assistant `allowlist` (only `dependabot[bot]` and `workers-devprod` are), so the required `CLAssistant` check can never pass on those PRs:

- the bot can't sign the CLA, and
- commenting `recheck` doesn't help, `issue_comment`-triggered CLA runs report their status against `main`, not the PR's head commit, so the required check on the release PR stays *"Expected — waiting for status to be reported"* indefinitely.

The result is that every Changesets release PR is blocked until someone admin-merges past the stuck check.

## What

Add `github-actions[bot]` to the CLA Assistant `allowlist`, alongside the existing `dependabot[bot]` and `workers-devprod`, so the automated release PRs satisfy the CLA check the same way Dependabot's already do.

## Note

This doesn't retroactively unblock the currently-open #191, its head commit already has no CLA check, so that one still needs an admin-merge (or a fresh commit to re-trigger). This change prevents future Version Packages PRs from hitting the same wall.