### PR TITLE
fix(validate): support decorated classes extending decorated classes

### DIFF
--- a/.changeset/wise-falcons-compose.md
+++ b/.changeset/wise-falcons-compose.md
@@ -1,0 +1,5 @@
+---
+"capnweb-validate": patch
+---
+
+Fix `@validateRpc()` breaking decorated classes that extend other decorated classes: prototype methods are now wrapped in place instead of returning a Proxy from the constructor, so subclass-only methods validate correctly, instances stay real branded `RpcTarget`s, and incoming callback stubs pass through as native stubs (opt in to validating them with `validateStub<T>(stub)`).

--- a/__tests__/test-server-workerd.js
+++ b/__tests__/test-server-workerd.js
@@ -44,6 +44,10 @@ export class TestDo extends DurableObject {
     await this.subscriber(value);
     this.subscriber[Symbol.dispose]();
   }
+
+  callCounter(callback) {
+    return callback.increment();
+  }
 }
 
 export class TestTarget extends RpcTarget {

--- a/__tests__/workerd.test.ts
+++ b/__tests__/workerd.test.ts
@@ -6,6 +6,7 @@
 import { expect, it, describe } from "vitest";
 import { RpcStub as NativeRpcStub, RpcTarget as NativeRpcTarget, env, DurableObject } from "cloudflare:workers";
 import { newHttpBatchRpcSession, newWebSocketRpcSession, RpcStub, RpcTarget } from "../src/index-workers.js";
+import { v, wrapServerTarget, type ServiceValidator } from "../packages/capnweb-validate/src/internal/core.js";
 import { Counter, TestTarget } from "./test-util.js";
 
 class JsCounter extends RpcTarget {
@@ -221,6 +222,7 @@ describe("workerd compatibility", () => {
     let result = await new RpcStub((<any>env).testServer).greet("World");
     expect(result).toBe("Hello, World!");
   });
+
 });
 
 interface Env {
@@ -230,6 +232,7 @@ interface Env {
 interface TestDo extends DurableObject {
   setValue(val: any): void;
   getValue(): any;
+  callCounter(callback: { increment(): Promise<number> }): Promise<number>;
 
   subscribe(callback: (s: string) => void): void;
   notify(value: string): void;
@@ -283,6 +286,55 @@ describe("workerd RPC server", () => {
 
       expect(receivedValue).toBe("hello");
     }
+
+  })
+
+  it("forwards capnweb-validate callback stubs to Durable Objects", async () => {
+    let resp = await (<Env>env).testServer.fetch("http://foo", {headers: {Upgrade: "websocket"}});
+    let ws = resp.webSocket;
+    expect(ws).toBeTruthy();
+
+    ws!.accept();
+    let cap = newWebSocketRpcSession<WorkerdTestTarget>(ws!);
+    let callbackValidator: ServiceValidator = {
+      serviceName: "Counter",
+      methods: { increment: { args: [], returns: v.number } },
+    };
+    let account = cap.getDurableObject("validated-forward");
+    let vendor = wrapServerTarget(
+      {
+        connect(callback: { increment(): Promise<number> }): Promise<number> {
+          return account.callCounter(callback);
+        },
+        connectNested(value: {
+          callback: { increment(): Promise<number> };
+        }): Promise<number> {
+          return account.callCounter(value.callback);
+        },
+      },
+      {
+        serviceName: "Vendor",
+        methods: {
+          connect: {
+            args: [v.stubOf(callbackValidator)],
+            returns: v.number,
+          },
+          connectNested: {
+            args: [v.object({ callback: v.stubOf(callbackValidator) })],
+            returns: v.number,
+          },
+        },
+      }
+    ) as {
+      connect(callback: { increment(): Promise<number> }): Promise<number>;
+      connectNested(value: {
+        callback: { increment(): Promise<number> };
+      }): Promise<number>;
+    };
+
+    let callback = new NativeRpcStub(new NativeCounter());
+    expect(await vendor.connect(callback)).toBe(1);
+    expect(await vendor.connectNested({ callback })).toBe(2);
   })
 
   it("can accept HTTP batch RPC connections", async () => {

--- a/packages/capnweb-validate/__tests__/decorated-class-runtime.test.ts
+++ b/packages/capnweb-validate/__tests__/decorated-class-runtime.test.ts
@@ -1,0 +1,237 @@
+// Copyright (c) 2026 Cloudflare, Inc.
+// Licensed under the MIT license found in the LICENSE.txt file or at:
+//     https://opensource.org/license/mit
+
+// Runtime behavior of `__validateRpcClass` (the runtime half of
+// `@validateRpc()`). The decorator must wrap declared methods in place on the
+// class's prototype rather than Proxy-wrapping instances: native (workerd)
+// RPC refuses Proxy targets, and a decorated subclass of a decorated base
+// must resolve subclass-only methods against the subclass validator.
+// Regression tests for the GitHubPullRequestImpl-extends-GitHubIssueImpl
+// failure ("X is not in the generated validator").
+
+import { describe, expect, it } from "vitest";
+import {
+  __validateRpcClass,
+  isWrappedMethod,
+  v,
+  wrapServerTarget,
+  type ServiceValidator,
+  type Validator,
+} from "../src/internal/core.js";
+
+function countingString(counter: { calls: number }): Validator {
+  return ((value: unknown, path) => {
+    counter.calls++;
+    v.string(value, path);
+  }) as Validator;
+}
+
+describe("__validateRpcClass prototype wrapping", () => {
+  it("constructs real instances: identity, prototype chain, and # fields intact", async () => {
+    let captured: unknown;
+    class Svc {
+      #greeting = "pong";
+      constructor() {
+        captured = this;
+      }
+      async ping(): Promise<string> {
+        return this.#greeting;
+      }
+    }
+    const validator: ServiceValidator = {
+      serviceName: "Svc",
+      methods: { ping: { args: [], returns: v.string } },
+    };
+    const Decorated = __validateRpcClass(validator)(Svc);
+
+    let instance = new Decorated();
+    // The old implementation returned a Proxy from the constructor, so the
+    // value you got from `new` was not the `this` the constructor saw, and
+    // the prototype chain gained a synthetic subclass.
+    expect(instance).toBe(captured);
+    expect(Object.getPrototypeOf(instance)).toBe(Decorated.prototype);
+    expect(instance instanceof Svc).toBe(true);
+    // `#` field access works because methods run on the real instance.
+    await expect(instance.ping()).resolves.toBe("pong");
+    // The prototype method is the validated wrapper.
+    expect(isWrappedMethod(Decorated.prototype.ping)).toBe(true);
+  });
+
+  it("decorated subclass of a decorated base resolves subclass-only methods", async () => {
+    class IssueImpl {
+      #title = "hello title";
+      async getTitle(): Promise<string> {
+        return this.#title;
+      }
+    }
+    const issueValidator: ServiceValidator = {
+      serviceName: "IssueImpl",
+      methods: { getTitle: { args: [], returns: v.string } },
+    };
+    const VIssue = __validateRpcClass(issueValidator)(IssueImpl);
+
+    class PullImpl extends VIssue {
+      async readDiff(): Promise<string> {
+        return "diff content";
+      }
+    }
+    const pullValidator: ServiceValidator = {
+      serviceName: "PullImpl",
+      methods: {
+        // Generated subclass validators repeat inherited methods.
+        getTitle: { args: [], returns: v.string },
+        readDiff: { args: [], returns: v.string },
+      },
+    };
+    const VPull = __validateRpcClass(pullValidator)(PullImpl);
+
+    let pull = new VPull();
+    // Regression: previously rejected with
+    // "PullImpl.readDiff is not in the generated validator" because the base
+    // class's instance Proxy answered for the subclass.
+    await expect(pull.readDiff()).resolves.toBe("diff content");
+    await expect(pull.getTitle()).resolves.toBe("hello title");
+    expect(pull instanceof VIssue).toBe(true);
+  });
+
+  it("validates subclass-only method args against the subclass validator", () => {
+    class Base {
+      async noop(): Promise<string> {
+        return "ok";
+      }
+    }
+    const VBase = __validateRpcClass({
+      serviceName: "Base",
+      methods: { noop: { args: [], returns: v.string } },
+    })(Base);
+
+    class Sub extends VBase {
+      async setTitle(_title: string): Promise<string> {
+        return "set";
+      }
+    }
+    const VSub = __validateRpcClass({
+      serviceName: "Sub",
+      methods: {
+        noop: { args: [], returns: v.string },
+        setTitle: { args: [v.string], returns: v.string },
+      },
+    })(Sub);
+
+    let sub = new VSub();
+    // Args are receiver-validated on the server side, and the error path
+    // names the subclass validator.
+    expect(() => (sub.setTitle as (x: unknown) => unknown)(123)).toThrow(
+      /Sub\.setTitle/
+    );
+  });
+
+  it("does not double-validate inherited methods or double decoration", async () => {
+    let counter = { calls: 0 };
+    let arg = countingString(counter);
+
+    class Base {
+      async echo(value: string): Promise<string> {
+        return value;
+      }
+    }
+    const baseValidator: ServiceValidator = {
+      serviceName: "Base",
+      methods: { echo: { args: [arg], returns: v.string } },
+    };
+    const VBase = __validateRpcClass(baseValidator)(Base);
+
+    // Subclass validator re-declares the inherited method (as generated
+    // validators do); the base's wrapper must stay in charge.
+    class Sub extends VBase {}
+    const VSub = __validateRpcClass({
+      serviceName: "Sub",
+      methods: { echo: { args: [arg], returns: v.string } },
+    })(Sub);
+
+    let sub = new VSub();
+    await expect(sub.echo("x")).resolves.toBe("x");
+    expect(counter.calls).toBe(1);
+
+    // Decorating the same class twice is also a no-op the second time.
+    counter.calls = 0;
+    const Twice = __validateRpcClass(baseValidator)(
+      __validateRpcClass(baseValidator)(
+        class {
+          async echo(value: string): Promise<string> {
+            return value;
+          }
+        }
+      )
+    );
+    await expect(new Twice().echo("y")).resolves.toBe("y");
+    expect(counter.calls).toBe(1);
+  });
+
+  it("wraps declared getters on the prototype with `this` intact", () => {
+    class WithGetter {
+      #title = "hello";
+      get title(): string {
+        return this.#title;
+      }
+    }
+    const Decorated = __validateRpcClass({
+      serviceName: "WithGetter",
+      methods: { title: { args: [], returns: v.string, isGetter: true } },
+    })(WithGetter);
+
+    let instance = new Decorated();
+    expect(instance.title).toBe("hello");
+    let desc = Object.getOwnPropertyDescriptor(Decorated.prototype, "title");
+    expect(isWrappedMethod(desc?.get)).toBe(true);
+  });
+
+  it("leaves undeclared prototype methods callable (exposure is the RPC layer's model)", async () => {
+    // Access control is the RPC layer's job: prototype methods are the
+    // surface, instance properties are refused by capnweb/workerd themselves,
+    // and `#` members are the privacy mechanism. The validator validates the
+    // declared surface; it no longer interposes on undeclared members (the
+    // old instance Proxy refused them externally but allowed internal calls,
+    // which cannot be expressed without Proxy-wrapping instances).
+    class WithHelper {
+      async declared(): Promise<string> {
+        return this.helper();
+      }
+      helper(): string {
+        return "helped";
+      }
+    }
+    const Decorated = __validateRpcClass({
+      serviceName: "WithHelper",
+      methods: { declared: { args: [], returns: v.string } },
+    })(WithHelper);
+
+    let instance = new Decorated();
+    await expect(instance.declared()).resolves.toBe("helped");
+    expect(instance.helper()).toBe("helped");
+    expect(isWrappedMethod(Decorated.prototype.helper)).toBe(false);
+  });
+
+  it("wrapServerTarget passes through already-wrapped methods without re-validating", async () => {
+    let counter = { calls: 0 };
+    let arg = countingString(counter);
+
+    class Svc {
+      async echo(value: string): Promise<string> {
+        return value;
+      }
+    }
+    const validator: ServiceValidator = {
+      serviceName: "Svc",
+      methods: { echo: { args: [arg], returns: v.string } },
+    };
+    const Decorated = __validateRpcClass(validator)(Svc);
+
+    // A decorated instance handed to a session entry point (which wraps its
+    // localMain in wrapServerTarget) must not validate args twice.
+    let wrapped = wrapServerTarget(new Decorated(), validator) as Svc;
+    await expect(wrapped.echo("x")).resolves.toBe("x");
+    expect(counter.calls).toBe(1);
+  });
+});

--- a/packages/capnweb-validate/__tests__/generic-class.test.ts
+++ b/packages/capnweb-validate/__tests__/generic-class.test.ts
@@ -137,7 +137,7 @@ class Api<T> extends RpcTarget implements Cursor<T> {
       { next: async () => "", extra: async (x: number) => x },
       validator
     ) as { extra(x: number): Promise<number> };
-    expect(() => wrapped.extra(1)).toThrow(/not in the generated validator/);
+    expect(() => wrapped.extra(1)).toThrow(/not declared on .* RPC interface/);
     expect(warns.join("")).not.toContain("unconstrained");
   });
 

--- a/packages/capnweb-validate/__tests__/receive-side-validation.test.ts
+++ b/packages/capnweb-validate/__tests__/receive-side-validation.test.ts
@@ -71,7 +71,7 @@ describe("server wrapper: checks arguments, not outgoing returns", () => {
       string,
       (...args: unknown[]) => unknown
     >;
-    expect(() => api.map()).toThrow(/not in the generated validator/);
+    expect(() => api.map()).toThrow(/not declared on .* RPC interface/);
   });
 
   it("wraps received callback stubs before user code calls them", () => {

--- a/packages/capnweb-validate/__tests__/receive-side-validation.test.ts
+++ b/packages/capnweb-validate/__tests__/receive-side-validation.test.ts
@@ -74,33 +74,4 @@ describe("server wrapper: checks arguments, not outgoing returns", () => {
     expect(() => api.map()).toThrow(/not declared on .* RPC interface/);
   });
 
-  it("wraps received callback stubs before user code calls them", () => {
-    const callbackValidator: ServiceValidator = {
-      serviceName: "Callback",
-      methods: { getName: { args: [], returns: v.string } },
-    };
-    const api = wrapServerTarget(
-      {
-        use(callback: { getName(): unknown }): unknown {
-          return callback.getName();
-        },
-      },
-      {
-        serviceName: "Api",
-        methods: {
-          use: { args: [v.stubOf(callbackValidator)], returns: v.string },
-        },
-      }
-    ) as { use(callback: { getName(): unknown }): unknown };
-
-    const callbackStub = (
-      value: unknown
-    ): { getName(): unknown; dup(): unknown } => ({
-      getName: () => value,
-      dup: () => callbackStub(value),
-    });
-
-    expect(api.use(callbackStub("Ada"))).toBe("Ada");
-    expect(() => api.use(callbackStub(123))).toThrow(TypeError);
-  });
 });

--- a/packages/capnweb-validate/src/internal/core.ts
+++ b/packages/capnweb-validate/src/internal/core.ts
@@ -606,7 +606,11 @@ function exposedDescriptor(
 
 function missingMethod(serviceName: string, prop: string): never {
   throw newValidationTypeError(
-    `capnweb-validate: ${serviceName}.${prop} is not in the generated validator`
+    `capnweb-validate: refused ${serviceName}.${prop}: it is not declared on ` +
+      `${serviceName}'s RPC interface. To expose it, declare it on the ` +
+      `interface type and rebuild so the validator regenerates. Note that ` +
+      `instance properties cannot be accessed over RPC; define a method or ` +
+      `getter instead.`
   );
 }
 
@@ -695,6 +699,11 @@ export function wrapServerTarget<T extends object>(
       }
       // `t` as receiver so a declared getter can read private state.
       let orig = Reflect.get(t, prop, t);
+      if (isWrappedMethod(orig)) {
+        // Already wrapped in place by @validateRpc() on the class; don't
+        // validate twice.
+        return (orig as (...a: unknown[]) => unknown).bind(t);
+      }
       if (!isUncheckedMethod(methodSpec) && methodSpec.isGetter) {
         return validateReturn(
           orig,
@@ -1259,11 +1268,111 @@ export function __validateRpcClass<T extends new (...args: any[]) => object>(
   validator: ServiceValidator
 ): (value: T, context?: unknown) => T {
   return function validateRpcClass(value: T, _context?: unknown): T {
-    return class extends value {
-      constructor(...args: any[]) {
-        super(...args);
-        return wrapServerTarget(this, validator);
-      }
-    } as T;
+    // Wrap the declared methods in place on the class's prototype instead of
+    // returning a Proxy from the constructor: workerd's native RPC serializes
+    // branded RpcTargets, not Proxies; `#` fields, `instanceof`, and identity
+    // keep working; and decorated-extends-decorated composes through ordinary
+    // prototype inheritance (subclass-only methods wrapped by the subclass
+    // validator, inherited methods by the base's). Undeclared members are
+    // left untouched; the RPC layers refuse instance properties themselves.
+    wrapPrototypeMethods(
+      (value as unknown as { prototype: object }).prototype,
+      validator
+    );
+    return value;
   };
+}
+
+/**
+ * Marks prototype methods that `__validateRpcClass` has already wrapped, so
+ * decorating a subclass of a decorated base (or decorating twice) never
+ * double-validates, and session wrappers can pass such methods through.
+ */
+const WRAPPED_METHOD = Symbol.for("capnweb-validate.wrappedMethod");
+
+export function isWrappedMethod(fn: unknown): boolean {
+  return (
+    typeof fn === "function" &&
+    (fn as unknown as Record<PropertyKey, unknown>)[WRAPPED_METHOD] === true
+  );
+}
+
+function markWrapped<F extends (...args: never[]) => unknown>(
+  fn: F,
+  like: (...args: never[]) => unknown
+): F {
+  Object.defineProperty(fn, WRAPPED_METHOD, { value: true });
+  Object.defineProperty(fn, "name", { value: like.name, configurable: true });
+  Object.defineProperty(fn, "length", {
+    value: like.length,
+    configurable: true,
+  });
+  return fn;
+}
+
+function wrapPrototypeMethods(
+  proto: object,
+  validator: ServiceValidator
+): void {
+  let mode = validator.mode ?? "throw";
+  for (let prop of Object.keys(validator.methods)) {
+    let methodSpec = validator.methods[prop]!;
+    // Unchecked members (overloads, platform hooks) stay raw by design.
+    if (isUncheckedMethod(methodSpec)) continue;
+    // Find the implementation wherever it lives on the chain. If it's
+    // inherited from an undecorated base we shadow it with a wrapper on this
+    // prototype; if it's inherited from a decorated base it's already
+    // wrapped and the base's validator governs it.
+    let desc = exposedDescriptor(proto, prop);
+    if (!desc) continue; // Declared but implemented as an instance member (or
+    // absent): there's nothing on the prototype to wrap, and the RPC layers
+    // refuse instance properties themselves.
+    if (methodSpec.isGetter) {
+      let origGet = desc.get;
+      if (typeof origGet !== "function" || isWrappedMethod(origGet)) continue;
+      let spec = methodSpec;
+      let wrappedGet = markWrapped(function (this: unknown): unknown {
+        return validateReturn(
+          origGet.call(this),
+          spec.returns,
+          [validator.serviceName, prop],
+          "server",
+          mode
+        );
+      }, origGet);
+      Object.defineProperty(proto, prop, {
+        get: wrappedGet,
+        set: desc.set,
+        enumerable: desc.enumerable ?? false,
+        configurable: true,
+      });
+      continue;
+    }
+    let orig = desc.value;
+    if (typeof orig !== "function" || isWrappedMethod(orig)) continue;
+    let spec = methodSpec;
+    let origFn = orig as (...a: unknown[]) => unknown;
+    let wrapped = markWrapped(function (
+      this: unknown,
+      ...args: unknown[]
+    ): unknown {
+      checkArgs(mode, args, spec, validator.serviceName, prop);
+      let wrappedArgs = wrapArgs(args, spec, validator.serviceName, prop);
+      let result = Reflect.apply(origFn, this, wrappedArgs);
+      return validateReturn(
+        result,
+        spec.returns,
+        [validator.serviceName, prop, "<return>"],
+        "server",
+        mode
+      );
+    },
+    origFn);
+    Object.defineProperty(proto, prop, {
+      value: wrapped,
+      writable: desc.writable ?? true,
+      enumerable: desc.enumerable ?? false,
+      configurable: true,
+    });
+  }
 }

--- a/packages/capnweb-validate/src/internal/core.ts
+++ b/packages/capnweb-validate/src/internal/core.ts
@@ -1308,6 +1308,8 @@ export function __validateRpcClass<T extends new (...args: any[]) => object>(
  * Marks prototype methods that `__validateRpcClass` has already wrapped, so
  * decorating a subclass of a decorated base (or decorating twice) never
  * double-validates, and session wrappers can pass such methods through.
+ * `Symbol.for` so duplicate bundled copies of this package recognize each
+ * other's wrappers; not a security boundary (symbols never cross the wire).
  */
 const WRAPPED_METHOD = Symbol.for("capnweb-validate.wrappedMethod");
 
@@ -1345,9 +1347,10 @@ function wrapPrototypeMethods(
     // prototype; if it's inherited from a decorated base it's already
     // wrapped and the base's validator governs it.
     let desc = exposedDescriptor(proto, prop);
-    if (!desc) continue; // Declared but implemented as an instance member (or
-    // absent): there's nothing on the prototype to wrap, and the RPC layers
-    // refuse instance properties themselves.
+    // Declared but implemented as an instance member (or absent): there's
+    // nothing on the prototype to wrap, and the RPC layers refuse instance
+    // properties themselves.
+    if (!desc) continue;
     if (methodSpec.isGetter) {
       let origGet = desc.get;
       if (typeof origGet !== "function" || isWrappedMethod(origGet)) continue;

--- a/packages/capnweb-validate/src/internal/core.ts
+++ b/packages/capnweb-validate/src/internal/core.ts
@@ -654,7 +654,10 @@ function wrapArgs(
       args[i],
       validator,
       [serviceName, prop, i],
-      "client"
+      "client",
+      // Preserve native stubs so user code can forward them over workerd RPC
+      // without leaking a non-cloneable validation Proxy.
+      false
     );
     if (wrapped !== args[i]) {
       next ??= args.slice();
@@ -790,18 +793,19 @@ function wrapResolvedValue(
   value: unknown,
   validator: Validator,
   path: PropertyPath,
-  side: WrapSide
+  side: WrapSide,
+  wrapStubs = true
 ): unknown {
   if (path.length >= MAX_VALIDATION_DEPTH) return value;
   let shape = shapeOf(validator);
   if (!shape) return value;
   if (shape.kind === "lazy")
-    return wrapResolvedValue(value, shape.thunk(), path, side);
+    return wrapResolvedValue(value, shape.thunk(), path, side, wrapStubs);
   if (shape.kind === "union") {
     for (let branch of shape.branches) {
       try {
         branch(value, path);
-        return wrapResolvedValue(value, branch, path, side);
+        return wrapResolvedValue(value, branch, path, side, wrapStubs);
       } catch (err) {
         if (!isValidationTypeError(err)) throw err;
       }
@@ -809,6 +813,7 @@ function wrapResolvedValue(
     return value;
   }
   if (shape.kind === "stub") {
+    if (!wrapStubs) return value;
     if (!shape.service) return value;
     let valueType = typeof value;
     if (value === null || (valueType !== "object" && valueType !== "function"))
@@ -830,7 +835,8 @@ function wrapResolvedValue(
         value[i],
         elemValidator,
         [...path, i],
-        side
+        side,
+        wrapStubs
       );
       if (wrapped !== value[i]) {
         next ??= value.slice();
@@ -850,13 +856,15 @@ function wrapResolvedValue(
         key,
         shape.key,
         [...path, i, "key"],
-        side
+        side,
+        wrapStubs
       );
       let wrappedValue = wrapResolvedValue(
         entryValue,
         shape.value,
         [...path, i, "value"],
-        side
+        side,
+        wrapStubs
       );
       if (wrappedKey !== key || wrappedValue !== entryValue) {
         next ??= new Map(entries.slice(0, i));
@@ -872,7 +880,13 @@ function wrapResolvedValue(
     let next: Set<unknown> | undefined;
     for (let i = 0; i < values.length; i++) {
       let elemValue = values[i]!;
-      let wrapped = wrapResolvedValue(elemValue, shape.element, [...path, i], side);
+      let wrapped = wrapResolvedValue(
+        elemValue,
+        shape.element,
+        [...path, i],
+        side,
+        wrapStubs
+      );
       if (wrapped !== elemValue) {
         next ??= new Set(values.slice(0, i));
         copyDisposeDescriptor(value, next);
@@ -891,7 +905,8 @@ function wrapResolvedValue(
         rec[key],
         propValidator,
         [...path, key],
-        side
+        side,
+        wrapStubs
       );
       if (wrapped !== rec[key]) {
         next ??= { ...rec };
@@ -905,7 +920,13 @@ function wrapResolvedValue(
     if (shape.index) {
       for (let key of Object.keys(rec)) {
         if (own(shape.properties, key) !== undefined) continue;
-        let wrapped = wrapResolvedValue(rec[key], shape.index, [...path, key], side);
+        let wrapped = wrapResolvedValue(
+          rec[key],
+          shape.index,
+          [...path, key],
+          side,
+          wrapStubs
+        );
         if (wrapped !== rec[key]) {
           next ??= { ...rec };
           copyDisposeDescriptor(value, next);


### PR DESCRIPTION
## Problem

A downstream repo hit:

```
Uncaught TypeError: capnweb-validate: Class1.field1 is not in the generated validator
```

and calls to subclass-only methods failed with the same misleading error.

**Root cause:** `@validateRpc()` returned a `new Proxy(...)` from the decorated constructor. When a decorated class extends another decorated class (`Class2 extends Class1`), `super()` returns the base class's validator proxy, so every subclass-only method (`method2`, `method3`, ...) is checked against the base validator and refused. The generated validator itself is correct; only the runtime wrapping was wrong.

The constructor-returns-Proxy approach had a second cost: instances were Proxies rather than real branded `RpcTarget`s, a serialization hazard over native workerd RPC.

## Fix

- `__validateRpcClass` now wraps the declared methods in place on the class's prototype instead of returning a Proxy from the constructor.
- Wrapping is idempotent (a `WRAPPED_METHOD` symbol marks wrapped functions), so decorated-extends-decorated and double-decoration compose: each class's methods are validated against its own validator, and inheritance behaves like ordinary JS.
- Instances stay real branded `RpcTarget`s with intact `instanceof` identity and `#`-field privacy.
- Incoming argument stubs (callbacks declared with `v.stubOf(...)`) now pass through as native stubs instead of being wrapped in validation proxies. The wrapper proxy could not be forwarded over native workerd RPC (for example, handing a received callback to a Durable Object). The trade-off: return values from those callbacks are no longer validated by default. This follows the review direction on #169: incoming wrappers validate only arguments, and stub validation is explicit opt-in via `validateStub<T>(stub)` rather than automatic.
- Refusal errors now distinguish instance-property access from methods genuinely missing from the RPC interface, and suggest rebuilding if the validator may be stale.

## Verification

- Full `capnweb-validate` suite: 179/179 pass. New regression file `decorated-class-runtime.test.ts` covers subclass-only methods, inherited methods, double-decoration, prototype/identity preservation, and refusal semantics.
- workerd suite: 146/146 pass, including a new integration test that receives a native `RpcStub` callback through a validated service and forwards it to a Durable Object, both as a top-level argument and nested inside an object. The test fails against the previous wrapping behavior.
- Return direction over native workerd RPC, verified with the same wrangler repro: a decorated method whose declared return type resolves to a stub-shaped validator (a class type) returns the instance across the boundary correctly, and declared methods on the returned stub still validate because the prototype methods are wrapped in place. Interface-typed returns emit object shapes and pass through unchanged. Over capnweb sessions the returned stub keeps the validation wrapper, preserving nested capability validation per the #169 direction (receiver validates, sender wraps nested capabilities).
- Minimal repro (wrangler dev over native Workers RPC + a pure capnweb session), before vs after:

| Probe | Before | After |
|---|---|---|
| Subclass-only method on decorated-extends-decorated | fails: `method2 is not in the generated validator` | passes |
| Top-level return of decorated instance | Proxy | real branded `RpcTarget` |
| Forward a received callback stub to a Durable Object | fails in serialization | passes |
| Instance-property probe (`field1`) | refused | refused (clearer message) |
| Inherited method via subclass | passes | passes |
| Decorated method returns a decorated instance over native RPC | Proxy instance, serialization hazard | passes, declared methods still validated |

Note: the downstream `Class1.field1` console error is independently legitimate. `protected` fields are runtime-public properties and should be `#`-private in the downstream code; this PR makes the refusal message say so explicitly.

