### PR TITLE
fix(batch): add missing early return in nodeHttpBatchRpcResponse on non-POST

### DIFF
--- a/.changeset/non-post-early-return.md
+++ b/.changeset/non-post-early-return.md
@@ -1,0 +1,6 @@
+---
+"capnweb": patch
+---
+
+Fix nodeHttpBatchRpcResponse leaving the connection open and crashing with
+ERR_HTTP_HEADERS_SENT on non-POST requests. It now returns 405 immediately.

--- a/__tests__/index.test.ts
+++ b/__tests__/index.test.ts
@@ -2069,6 +2069,12 @@ describe("HTTP requests", () => {
     expect(await Promise.all([promise1, promise2, promise3]))
         .toStrictEqual([36, 5, 9]);
   });
+
+  it("rejects non-POST requests with 405", async () => {
+    let response = await fetch(`http://${inject("testServerHost")}`, { method: "GET" });
+    expect(response.status).toBe(405);
+    await response.text();
+  });
 });
 
 describe("WebSockets", () => {

--- a/src/batch.ts
+++ b/src/batch.ts
@@ -178,7 +178,9 @@ export async function nodeHttpBatchRpcResponse(
       headers?: OutgoingHttpHeaders | OutgoingHttpHeader[],
     }): Promise<void> {
   if (request.method !== "POST") {
-    response.writeHead(405, "This endpoint only accepts POST requests.");
+    response.writeHead(405, "This endpoint only accepts POST requests.", options?.headers);
+    response.end();
+    return;
   }
 
   let body = await new Promise<string>((resolve, reject) => {


### PR DESCRIPTION
## Summary

`nodeHttpBatchRpcResponse` wrote a 405 status for non-POST requests via `response.writeHead(405, ...)` but was missing `response.end()` and `return`. Execution fell through into the full RPC pipeline unconditionally, then crashed with `ERR_HTTP_HEADERS_SENT` when the function later tried to write the 200 response — leaving the TCP connection open until timeout.

The Fetch API counterpart (`newHttpBatchRpcResponse`) was unaffected; it already returned a 405 `Response` immediately.

## Changes

- `src/batch.ts`: add `response.end()` and `return` after the 405 `writeHead` call in `nodeHttpBatchRpcResponse`

## Test plan

- [ ] Verify a non-POST request to a `nodeHttpBatchRpcResponse` endpoint now receives a 405 with a closed connection and no RPC handlers are invoked
- [ ] Verify a valid POST request continues to work normally