### PR TITLE
Skip validation for fetch and connect lifecycle methods on WorkerEntrypoint and DurableObject.

### DIFF
--- a/.changeset/calm-socks-connect.md
+++ b/.changeset/calm-socks-connect.md
@@ -1,0 +1,5 @@
+---
+"capnweb-validate": patch
+---
+
+Treat Workers `fetch` and `connect` lifecycle methods as passthrough methods on `WorkerEntrypoint` and `DurableObject` targets.

--- a/packages/capnweb-validate/__tests__/transform-module.test.ts
+++ b/packages/capnweb-validate/__tests__/transform-module.test.ts
@@ -64,6 +64,47 @@ declare module "capnweb-validate/capnweb" {
 }
 `;
 
+const CAPNWEB_MARKER_SHIM = `
+declare module "capnweb-validate/capnweb" {
+  export function newWorkersRpcResponse(request: Request, target: object): Promise<Response>;
+}
+`;
+
+// Matches how @cloudflare/workers-types ships these bases: a
+// `CloudflareWorkersModule` namespace re-exported with `export =`.
+const WORKERS_TYPES_PACKAGE = `
+declare namespace CloudflareWorkersModule {
+  export abstract class WorkerEntrypoint<Env = unknown> {
+    protected ctx: unknown;
+    protected env: Env;
+    fetch?(request: Request): Response | Promise<Response>;
+    tailStream?(event: unknown): unknown;
+  }
+  export abstract class DurableObject<Env = unknown> {
+    protected ctx: unknown;
+    protected env: Env;
+    alarm?(): void | Promise<void>;
+    fetch?(request: Request): Response | Promise<Response>;
+  }
+}
+declare module "cloudflare:workers" {
+  export = CloudflareWorkersModule;
+}
+`;
+
+// Resolve the declarations from a real `@cloudflare/workers-types` path so the
+// transform's origin checks fire, without depending on the installed types.
+function typesPackage(name: string, body: string): Record<string, string> {
+  return {
+    [`node_modules/${name}/package.json`]: JSON.stringify({
+      name,
+      version: "0.0.0",
+      types: "index.d.ts",
+    }),
+    [`node_modules/${name}/index.d.ts`]: body,
+  };
+}
+
 describe("transformModule", () => {
   it("server: rewrites newWorkersRpcResponse and emits a validator", () => {
     let { code } = transform(`
@@ -321,6 +362,89 @@ describe("transformModule", () => {
     const validator = loadValidator(code);
     expect(Object.keys(validator.methods)).toEqual(["rpc"]);
     expect(validator.passthrough).toEqual(expect.arrayContaining(["fetch"]));
+  });
+
+  // The server-marker path did no platform filtering before this change. Assert
+  // parity with the decorator path for both an inherited hook and `connect`.
+  it.each([
+    ["WorkerEntrypoint", "tailStream"],
+    ["DurableObject", "alarm"],
+  ] as const)(
+    "server marker: filters %s subclass platform + connect methods",
+    (baseName, inheritedHook) => {
+      let { code } = transform(`
+        import { ${baseName} } from "cloudflare:workers";
+        import { newWorkersRpcResponse } from "capnweb-validate/capnweb";
+        class Base extends ${baseName} {}
+        class Api extends Base {
+          // Non-cloneable arg: the build would fail here if connect were
+          // validated instead of passed through.
+          connect(socket: WeakMap<object, number>): void {}
+          rpc(x: string): Promise<string> {
+            return null as any;
+          }
+        }
+        export function handler(req: Request): Promise<Response> {
+          return newWorkersRpcResponse(req, new Api());
+        }
+      `);
+      const validator = loadValidator(code);
+      expect(Object.keys(validator.methods)).toEqual(["rpc"]);
+      expect(validator.passthrough).toEqual(
+        expect.arrayContaining(["fetch", inheritedHook, "connect"])
+      );
+    }
+  );
+
+  it("server marker: filters connect from package-shaped workers types", () => {
+    // Drives the `@cloudflare/workers-types` path and `CloudflareWorkersModule`
+    // namespace origin checks that the inline `cloudflare:workers` shim does not.
+    let { code } = transformFixture(
+      `
+        import { WorkerEntrypoint } from "cloudflare:workers";
+        import { newWorkersRpcResponse } from "capnweb-validate/capnweb";
+        class Api extends WorkerEntrypoint {
+          connect(socket: WeakMap<object, number>): void {}
+          rpc(x: string): Promise<string> {
+            return null as any;
+          }
+        }
+        export function handler(req: Request): Promise<Response> {
+          return newWorkersRpcResponse(req, new Api(undefined as any, {}));
+        }
+      `,
+      {
+        shim: CAPNWEB_MARKER_SHIM,
+        imports: "",
+        compilerOptions: { esModuleInterop: true },
+        files: typesPackage("@cloudflare/workers-types", WORKERS_TYPES_PACKAGE),
+        rootFiles: ["node_modules/@cloudflare/workers-types/index.d.ts"],
+      }
+    );
+    const validator = loadValidator(code);
+    expect(Object.keys(validator.methods)).toEqual(["rpc"]);
+    expect(validator.passthrough).toEqual(
+      expect.arrayContaining(["fetch", "connect"])
+    );
+  });
+
+  it("server marker: keeps non-Workers RpcTarget connect methods validated", () => {
+    let { code } = transform(`
+      import { RpcTarget } from "capnweb";
+      import { newWorkersRpcResponse } from "capnweb-validate/capnweb";
+      class Api extends RpcTarget {
+        connect(x: string): Promise<string> {
+          return null as any;
+        }
+      }
+      export function handler(req: Request): Promise<Response> {
+        return newWorkersRpcResponse(req, new Api());
+      }
+    `);
+    const validator = loadValidator(code);
+    expect(Object.keys(validator.methods)).toEqual(["connect"]);
+    expect(checkedMethod(validator, "connect").args[0]).toBe(v.string);
+    expect(validator.passthrough).toBeUndefined();
   });
 
   it("decorator: filters inherited DurableObject platform methods", () => {

--- a/packages/capnweb-validate/src/transform/transform-module.ts
+++ b/packages/capnweb-validate/src/transform/transform-module.ts
@@ -511,22 +511,7 @@ function resolveDecoratorShape(
   if (isWorkerEntrypointType(checker, classType)) {
     shape.targetKind = "workerEntrypoint";
   }
-  // Pass-through names come from the class (the proxy wraps its instances), not
-  // the possibly-narrowed resolved surface.
-  let platform = collectPlatformMethodNames(checker, classType);
-  if (platform.length) {
-    let platformMethods = new Set(platform);
-    shape = {
-      ...shape,
-      methods: shape.methods.filter(
-        (method) => !platformMethods.has(method.name)
-      ),
-      passthrough: platform,
-    };
-  } else {
-    shape.passthrough = undefined;
-  }
-  return shape;
+  return applyPlatformPassthrough(checker, classType, shape);
 }
 
 function getDecoratorTypeArgumentNode(
@@ -769,7 +754,25 @@ function resolveCallSiteShape(
     type = checker.getTypeAtLocation(arg);
   }
   if (isTooGeneric(type)) return null;
-  return resolveServiceShape(ts, checker, type);
+  let shape = resolveServiceShape(ts, checker, type);
+  return shape && applyPlatformPassthrough(checker, type, shape);
+}
+
+function applyPlatformPassthrough(
+  checker: ts.TypeChecker,
+  type: ts.Type,
+  shape: ServiceShape
+): ServiceShape {
+  // Pass-through names come from the concrete target type, not the
+  // possibly-narrowed resolved surface, since the proxy wraps the instance.
+  let platform = collectPlatformMethodNames(checker, type);
+  if (platform.length === 0) return { ...shape, passthrough: undefined };
+  let platformMethods = new Set(platform);
+  return {
+    ...shape,
+    methods: shape.methods.filter((method) => !platformMethods.has(method.name)),
+    passthrough: platform,
+  };
 }
 
 function getExplicitTypeArgument(

--- a/packages/capnweb-validate/src/transform/type-introspector.ts
+++ b/packages/capnweb-validate/src/transform/type-introspector.ts
@@ -1245,12 +1245,25 @@ function isRpcReadableProperty(
   );
 }
 
+// Lifecycle entrypoints the Workers runtime invokes directly, not over RPC.
+// Matched by name because `connect` is not declared on either base type.
+const WORKERS_LIFECYCLE_METHOD_NAME_FALLBACKS = ["fetch", "connect"] as const;
+
+function isWorkersLifecycleBaseSymbol(sym: ts.Symbol): boolean {
+  let name = sym.getName();
+  return (
+    (name === "WorkerEntrypoint" || name === "DurableObject") &&
+    isRpcRuntimeSymbol(sym)
+  );
+}
+
 // Platform-inherited method names of `type` (e.g. WorkerEntrypoint `fetch`).
 export function collectPlatformMethodNames(
   checker: ts.TypeChecker,
   type: ts.Type
 ): string[] {
   let names = new Set<string>();
+  let isWorkersPlatformTarget = false;
   let add = (prop: ts.Symbol): void => {
     if (isSymbolNamedProperty(prop)) return;
     if (RPC_CAPABILITY_BRAND_NAMES.has(prop.getName())) return;
@@ -1275,12 +1288,20 @@ export function collectPlatformMethodNames(
       seen.add(base);
       let sym = base.getSymbol();
       if (sym && isRpcRuntimeSymbol(sym)) {
+        if (isWorkersLifecycleBaseSymbol(sym)) isWorkersPlatformTarget = true;
         for (let prop of checker.getPropertiesOfType(base)) add(prop);
       }
       walk(base);
     }
   };
   walk(type);
+  if (isWorkersPlatformTarget) {
+    // Catches overrides and undeclared hooks that the base-type walk misses.
+    for (let name of WORKERS_LIFECYCLE_METHOD_NAME_FALLBACKS) {
+      let prop = checker.getPropertyOfType(type, name);
+      if (prop) add(prop);
+    }
+  }
   return [...names];
 }
 


### PR DESCRIPTION
`@validateRpc` and the server markers (`newWorkersRpcResponse` etc.) treat `fetch` and `connect` as platform lifecycle entrypoints on `WorkerEntrypoint` and `DurableObject` targets: the Workers runtime invokes them directly rather than over RPC, so they pass through unvalidated instead of being validated as RPC methods.

The platform-passthrough filtering used by the decorator path is now factored into a shared `applyPlatformPassthrough` and also applied on the server-marker call-site path, which previously did no platform filtering. `fetch` is a declared, overridable hook on both base types; `connect` is not declared on either, so it is matched by name within a source-verified Workers-base gate.

Tests cover the marker path for both base types (including a subclass chain), a package-shaped `@cloudflare/workers-types` fixture that exercises the real symbol-origin checks, and a negative case proving a non-Workers `RpcTarget.connect` stays validated.