### PR TITLE
fix(tests): bind test server to loopback so Firefox/WebKit can connect

### DIFF
--- a/__tests__/test-server.ts
+++ b/__tests__/test-server.ts
@@ -50,8 +50,14 @@ export async function setup(project: TestProject) {
     newWebSocketRpcSession(ws as any, new TestTarget());
   })
 
-  // Listen on an ephemeral port for testing purposes.
-  httpServer.listen(0);
+  // Listen on an ephemeral port for testing purposes. Bind explicitly to the IPv4 loopback
+  // address: with no host, Node binds the IPv6 wildcard `::`, which is then handed to clients as
+  // the connect target. Chromium tolerates connecting to `[::]`, but Firefox and WebKit reject it
+  // ("connection failed" / NetworkError), so use a concrete loopback address all clients accept.
+  //
+  // Passing a host makes listen() take the async DNS-resolution path, so we must wait for the
+  // "listening" event before address() is populated (with no host, binding is synchronous).
+  await new Promise<void>((resolve) => httpServer!.listen(0, "127.0.0.1", resolve));
   let addr = httpServer.address() as AddressInfo;
 
   // Provide the server address to tests.


### PR DESCRIPTION
The global test server called `httpServer.listen(0)` with no host, so on dual-stack hosts Node binds the IPv6 wildcard `::`. That address is then provided to clients verbatim as `testServerHost`, so tests connect to `http://[::]:PORT` / `ws://[::]:PORT`.

Chromium tolerates connecting to the wildcard `[::]`, but Firefox and WebKit reject it, causing the `browsers-without-using` project to fail deterministically on those engines:

  - HTTP requests > can perform a batch HTTP request  (NetworkError / Load failed)
  - WebSockets > can open a WebSocket connection      (WebSocket connection failed)

Bind explicitly to `127.0.0.1` so every engine gets a concrete loopback target. Passing a host makes `listen()` take the async DNS-resolution path, so we await the "listening" event before reading `address()` (with no host, binding was synchronous).

Verified on macOS: Firefox and WebKit go from failing those two tests to passing; node and workerd are unaffected.