### PR TITLE
fix: include root capnweb package in changesets workspace so it can be released

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -10,5 +10,8 @@
   "access": "public",
   "baseBranch": "main",
   "updateInternalDependencies": "patch",
-  "ignore": []
+  "ignore": [],
+  "___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH": {
+    "onlyUpdatePeerDependentsWhenOutOfRange": true
+  }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.8.0",
       "license": "MIT",
       "workspaces": [
+        ".",
         "packages/*"
       ],
       "devDependencies": {
@@ -3769,11 +3770,8 @@
       "license": "MIT"
     },
     "node_modules/capnweb": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/capnweb/-/capnweb-0.8.0.tgz",
-      "integrity": "sha512-BK/TuXUiyfLSKsmjojn70yN7oYG/JJzoURZ3tckjg5Zj2KcygPm0A5jyOlswK7SYB4f0Gh9tt+RZ132b80iLfA==",
-      "dev": true,
-      "license": "MIT"
+      "resolved": "",
+      "link": true
     },
     "node_modules/capnweb-validate": {
       "resolved": "packages/capnweb-validate",

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "access": "public"
   },
   "workspaces": [
+    ".",
     "packages/*"
   ],
   "scripts": {


### PR DESCRIPTION
## Why

The automated release is broken for the root **`capnweb`** package. The release workflow (`release.yml` → `./.github/changeset-version.sh` → `npx changeset version`) fails outright whenever a changeset targets `capnweb`:

```
🦋 error Error: Found changeset quiet-dragons-hunt for package capnweb which is not in the workspace
```

Root cause: `capnweb` is a published, public package (`"name": "capnweb"`, currently `0.8.0`), but the root `package.json` only declared `"workspaces": ["packages/*"]`. Changesets discovers releasable packages from the workspaces globs (via `@manypkg/get-packages`), so the **root package was invisible to it**. Any changeset that bumps `capnweb` — e.g. `quiet-dragons-hunt.md` from the encoding-levels work in #186 — makes `assembleReleasePlan` throw, and the release job dies before it can version or publish anything.

Net effect: the child workspace `packages/capnweb-validate` could be released, but the main `capnweb` package could not — so the encoding-levels release never shipped.

## What

Make the root `capnweb` package a discoverable workspace so Changesets can version and publish it.

- **`package.json`** — add `"."` to `workspaces` alongside `packages/*`, so the root package is part of the workspace set.
- **`package-lock.json`** — regenerated by `npm install`. `capnweb` (referenced by `capnweb-validate`'s `devDependency`) now resolves as a workspace symlink (`"link": true`) instead of downloading the published `0.8.0` tarball from the registry, so the monorepo builds and tests against local source.
- **`.changeset/config.json`** — add `onlyUpdatePeerDependentsWhenOutOfRange: true`. Now that `capnweb` is a workspace package and `capnweb-validate` declares `peerDependencies.capnweb: ">=0.7.0"`, Changesets' default behavior would force a `capnweb-validate` release on every `capnweb` bump. Since the new `capnweb` version still satisfies that peer range, this flag suppresses the spurious bump and only bumps peer-dependents when the new version actually falls outside their declared range.

## Verification

With the fix, `changeset status` correctly plans the release and leaves `capnweb-validate` alone:

```
info Packages to be bumped at minor
 - capnweb 0.9.0
   - .changeset/quiet-dragons-hunt.md
```
