### PR TITLE
ci(cla): dispatch CLA check for generated release PRs

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -5,6 +5,12 @@ on:
   pull_request_target:
     types: [opened,synchronize]
   merge_group:
+  workflow_dispatch:
+    inputs:
+      pull_request:
+        description: 'Changesets release PR number'
+        required: true
+        type: string
 
 permissions:
   actions: write
@@ -16,6 +22,28 @@ jobs:
   CLAssistant:
     runs-on: ubuntu-latest
     steps:
+      - name: "Validate changesets release PR"
+        if: github.event_name == 'workflow_dispatch'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ inputs.pull_request }}
+        run: |
+          set -euo pipefail
+
+          pr="repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}"
+          state=$(gh api "$pr" --jq '.state')
+          head_sha=$(gh api "$pr" --jq '.head.sha')
+          head_ref=$(gh api "$pr" --jq '.head.ref')
+          head_repo=$(gh api "$pr" --jq '.head.repo.full_name')
+          author=$(gh api "$pr" --jq '.user.login')
+          commit_author=$(gh api "repos/${GITHUB_REPOSITORY}/commits/${head_sha}" --jq '.author.login // ""')
+          commit_committer=$(gh api "repos/${GITHUB_REPOSITORY}/commits/${head_sha}" --jq '.committer.login // ""')
+
+          if [[ "$state" != "open" || "$author" != "github-actions[bot]" || "$head_ref" != "changeset-release/main" || "$head_repo" != "$GITHUB_REPOSITORY" || "$head_sha" != "$GITHUB_SHA" || "$commit_author" != "github-actions[bot]" || "$commit_committer" != "github-actions[bot]" ]]; then
+            echo "Refusing dispatched CLA check for unexpected PR: state=$state author=$author head=$head_repo:$head_ref sha=$head_sha workflow_sha=$GITHUB_SHA commit_author=$commit_author commit_committer=$commit_committer"
+            exit 1
+          fi
+
       - name: "CLA Assistant"
         if: (github.event.issue.pull_request && (github.event.comment.body == 'recheck' || github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA')) || github.event_name == 'pull_request_target'
         uses: contributor-assistant/github-action@v2.6.1

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -39,8 +39,13 @@ jobs:
           commit_author=$(gh api "repos/${GITHUB_REPOSITORY}/commits/${head_sha}" --jq '.author.login // ""')
           commit_committer=$(gh api "repos/${GITHUB_REPOSITORY}/commits/${head_sha}" --jq '.committer.login // ""')
 
-          if [[ "$state" != "open" || "$author" != "github-actions[bot]" || "$head_ref" != "changeset-release/main" || "$head_repo" != "$GITHUB_REPOSITORY" || "$head_sha" != "$GITHUB_SHA" || "$commit_author" != "github-actions[bot]" || "$commit_committer" != "github-actions[bot]" ]]; then
-            echo "Refusing dispatched CLA check for unexpected PR: state=$state author=$author head=$head_repo:$head_ref sha=$head_sha workflow_sha=$GITHUB_SHA commit_author=$commit_author commit_committer=$commit_committer"
+          if [[ "$head_sha" != "$GITHUB_SHA" ]]; then
+            echo "Release PR head changed after dispatch: pr_sha=$head_sha workflow_sha=$GITHUB_SHA"
+            exit 1
+          fi
+
+          if [[ "$state" != "open" || "$author" != "github-actions[bot]" || "$head_ref" != "changeset-release/main" || "$head_repo" != "$GITHUB_REPOSITORY" || "$commit_author" != "github-actions[bot]" || "$commit_committer" != "github-actions[bot]" ]]; then
+            echo "Refusing dispatched CLA check for unexpected PR: state=$state author=$author head=$head_repo:$head_ref commit_author=$commit_author commit_committer=$commit_committer"
             exit 1
           fi
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,5 +1,6 @@
 name: Release
 permissions:
+  actions: write # to dispatch CLA on the changesets release branch
   contents: write # to create release (changesets/action)
   issues: write # to post issue comments (changesets/action)
   pull-requests: write # to create pull request (changesets/action)
@@ -42,6 +43,27 @@ jobs:
           publish: npx changeset publish
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: "Dispatch CLA for changesets release PR"
+        if: ${{ steps.changesets.outputs.pullRequestNumber != '' }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ steps.changesets.outputs.pullRequestNumber }}
+        run: |
+          set -euo pipefail
+
+          pr="repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}"
+          state=$(gh api "$pr" --jq '.state')
+          head_ref=$(gh api "$pr" --jq '.head.ref')
+          head_repo=$(gh api "$pr" --jq '.head.repo.full_name')
+          author=$(gh api "$pr" --jq '.user.login')
+
+          if [[ "$state" != "open" || "$author" != "github-actions[bot]" || "$head_ref" != "changeset-release/main" || "$head_repo" != "$GITHUB_REPOSITORY" ]]; then
+            echo "Refusing to dispatch CLA for unexpected PR: state=$state author=$author head=$head_repo:$head_ref"
+            exit 1
+          fi
+
+          gh workflow run cla.yml --ref "$head_ref" -f "pull_request=${PR_NUMBER}"
 
   prerelease:
     if: ${{ github.event.workflow_run.conclusion == 'success' && github.repository_owner == 'cloudflare' }}


### PR DESCRIPTION
Generated `Version Packages` PRs are opened by `github-actions[bot]` from `changeset-release/main`. In that path, the required `CLAssistant` check can be missing from the generated PR head SHA, leaving the PR blocked even though `github-actions[bot]` is already allowlisted by the CLA workflow.

This adds a guarded `workflow_dispatch` path for the CLA workflow and has the release workflow dispatch it against `changeset-release/main` after creating or updating the generated release PR. The dispatched job verifies that the PR is the expected open `github-actions[bot]` release PR and that the workflow SHA matches the PR head SHA before allowing the check to pass.

Tested:
- `ruby -e "require "yaml"; YAML.load_file(".github/workflows/cla.yml"); YAML.load_file(".github/workflows/release.yml")"`
- `git diff --check`