### PR TITLE
ci(cla): report dispatched CLA pass via commit status

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -49,6 +49,19 @@ jobs:
             exit 1
           fi
 
+      # dispatched runs are not associated with the PR, so report via commit status
+      - name: "Pass CLA via commit status"
+        if: github.event_name == 'workflow_dispatch'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          gh api -X POST "repos/${GITHUB_REPOSITORY}/statuses/${GITHUB_SHA}" \
+            -f state=success \
+            -f context=CLAssistant \
+            -f description="Changesets release PR: github-actions[bot] is CLA-allowlisted" \
+            -f target_url="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+
       - name: "CLA Assistant"
         if: (github.event.issue.pull_request && (github.event.comment.body == 'recheck' || github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA')) || github.event_name == 'pull_request_target'
         uses: contributor-assistant/github-action@v2.6.1


### PR DESCRIPTION
#204 wasn't enough. When `cla.yml` runs via `workflow_dispatch`, the run's check suite lands on the commit with `associated_prs=0`, so it never attaches to the release PR. The run goes green but the merge box never sees a `CLAssistant` check and the PR stays blocked on the required status check.

This keeps everything from #204 (trigger, validation guard, dispatch from release.yml) and only changes how the result is reported. After the guard passes, the workflow posts a commit status with context `CLAssistant` on `$GITHUB_SHA`. Statuses attach to the SHA directly, so they show up in the PR status rollup and satisfy the required check even with the ruleset pinned to the GitHub Actions app. No new permissions, the workflow already had `statuses: write`.

Tested end to end on my fork instead of experimenting here. Mirrored the ruleset (required status check `CLAssistant` pinned to the GitHub Actions app) and had a throwaway workflow open a fake release PR shaped like a real one, opened by github-actions[bot] from `changeset-release/main` with a bot-authored head commit so it passes the guard: https://github.com/teamchong/capnweb/pull/2. Before the fix it sat at `mergeStateStatus: BLOCKED` with an empty rollup, same as the incident here. Then I dispatched it the same way release.yml does (`gh workflow run cla.yml --ref changeset-release/main -f pull_request=2`, run: https://github.com/teamchong/capnweb/actions/runs/28710748911) and it flipped to `mergeable: true` with `CLAssistant: success` in the rollup.