### PR TITLE
ci(cla): allowlist ask-bonk[bot]

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -72,5 +72,5 @@ jobs:
           path-to-document: 'https://www.cloudflare.com/cla/'
           # branch should not be protected
           branch: 'cla-signatures'
-          allowlist: dependabot[bot],workers-devprod,github-actions[bot]
+          allowlist: dependabot[bot],workers-devprod,github-actions[bot],ask-bonk[bot]
           lock-pullrequest-aftermerge: false


### PR DESCRIPTION
## Summary
- Add `ask-bonk[bot]` to the CLA allowlist so review commits on PR branches don't leave the required `CLAssistant` check missing/failing.
- Same pattern as existing `dependabot[bot]` / `github-actions[bot]` entries.
- Motivated by #214, where an ask-bonk commit became HEAD and blocked merge waiting on CLAssistant.

## Test plan
- [ ] CI CLA workflow parses with the updated allowlist
- [ ] Next ask-bonk commit on a PR gets a green CLAssistant check on the new HEAD