### PR TITLE
Prevent Bonk from pushing commits.

### DIFF
--- a/.github/workflows/bonk-pr-review.yml
+++ b/.github/workflows/bonk-pr-review.yml
@@ -53,5 +53,6 @@ jobs:
           variant: "high"
           forks: "false"
           permissions: write
+          token_permissions: NO_PUSH
           opencode_version: 1.15.13 # pin to this version as certain ones cause ProviderInitError issues
           prompt: ${{ steps.prompt.outputs.value }}

--- a/.github/workflows/bonk.yml
+++ b/.github/workflows/bonk.yml
@@ -65,6 +65,7 @@ jobs:
           variant: "high"
           mentions: "/bonk,@ask-bonk"
           permissions: write
+          token_permissions: NO_PUSH
           agent: bonk
           opencode_version: 1.15.13 # pin to this version as certain ones cause ProviderInitError issues
           prompt: ${{ steps.prompt.outputs.value }}


### PR DESCRIPTION
Bonk ignored the review prompt on #201 and pushed a commit. Prompt instructions are not a reliable security boundary.

This sets token_permissions: NO_PUSH for both automatic reviews and /bonk invocations. Bonk retains permission to post comments, reviews, and suggestions, but cannot push commits.

Documentation: https://github.com/Cloudflare-Studio/ask-bonk/blob/24832587005550860c8ad13fd96519e731ca632a/README.md#token-scoping