### PR TITLE
fix: remove ~1ms HTTP batch latency floor on Node and Bun

### DIFF
--- a/.changeset/fix-batch-setimmediate.md
+++ b/.changeset/fix-batch-setimmediate.md
@@ -1,0 +1,5 @@
+---
+"capnweb": patch
+---
+
+Remove the ~1ms per-batch latency floor in the HTTP batch client on Node and Bun by flushing via `setImmediate` instead of the clamped `setTimeout(0)`.

--- a/src/batch.ts
+++ b/src/batch.ts
@@ -8,6 +8,12 @@ import type { IncomingMessage, ServerResponse, OutgoingHttpHeader, OutgoingHttpH
 
 type SendBatchFunc = (batch: string[]) => Promise<string[]>;
 
+// Yield a full macrotask; prefer setImmediate because Node/Bun clamp setTimeout(0) to 1ms.
+const yieldToMacrotask: () => Promise<void> =
+  typeof setImmediate === "function"
+    ? () => new Promise(resolve => setImmediate(resolve))
+    : () => new Promise(resolve => setTimeout(resolve, 0));
+
 class BatchClientTransport implements RpcTransport {
   constructor(sendBatch: SendBatchFunc) {
     this.#promise = this.#scheduleBatch(sendBatch);
@@ -55,7 +61,7 @@ class BatchClientTransport implements RpcTransport {
     // promise in order to explicitly indicate they want the results. Unfortunately, `await`ing
     // a thenable does not call `.then()` immediately -- for some reason it waits for a turn of
     // the microtask queue first, *then* calls `.then()`.
-    await new Promise(resolve => setTimeout(resolve, 0));
+    await yieldToMacrotask();
 
     if (this.#aborted !== undefined) {
       throw this.#aborted;


### PR DESCRIPTION
Node and Bun clamp setTimeout(0) to a 1ms minimum, which delayed every HTTP batch request. Schedule the batch flush with setImmediate where available to yield a macrotask without the clamp, keeping setTimeout(0) as the fallback for browsers and workerd. The macrotask timing that lets the application register .then() on RPC promises before the batch is sent is preserved.

Addresses https://github.com/cloudflare/capnweb/issues/219
