### PR TITLE
capnweb-validate: ignore extra args instead of refusing the call

### DIFF
--- a/.changeset/ignore-extra-args.md
+++ b/.changeset/ignore-extra-args.md
@@ -1,0 +1,5 @@
+---
+"capnweb-validate": patch
+---
+
+Ignore extra arguments past a method's declared parameters instead of refusing the call, and drop them before invoking the implementation.

--- a/packages/capnweb-validate/README.md
+++ b/packages/capnweb-validate/README.md
@@ -267,6 +267,35 @@ unvalidated with a warning. Collapse the overloads into a single signature with
 union parameters to validate the method, or `@skipRpcValidation()` to silence
 the warning.
 
+## Schema Evolution
+
+A validator built from one version of your types may receive values from a peer
+built from another.
+
+| Change                                | Result  |
+| ------------------------------------- | ------- |
+| Extra argument                        | Allowed |
+| Extra object property                 | Allowed |
+| Extra index-signature key             | Allowed |
+| New optional parameter / property     | Allowed |
+| Missing required parameter / property | Refused |
+| Renamed or retyped member             | Refused |
+| Changed tuple length, no rest element | Refused |
+| New union member                      | Refused |
+| New method                            | Refused |
+
+Remove a required member by making it optional in one release and deleting it in
+a later one.
+
+Extra arguments to a validated method are dropped before it runs, but extra
+object properties are forwarded to the implementation unvalidated. An index
+signature is the exception: it validates every property outside the declared
+ones.
+
+Keep `strictNullChecks` on. Without it TypeScript erases `null` from your types
+and the generated validator refuses a `null` that a peer built with it considers
+valid.
+
 ## License
 
 MIT.

--- a/packages/capnweb-validate/__tests__/extra-args.test.ts
+++ b/packages/capnweb-validate/__tests__/extra-args.test.ts
@@ -1,0 +1,107 @@
+// Extra args past the declared parameter list are ignored, so a newer caller
+// can pass a parameter this build's signature doesn't know about.
+import { describe, it, expect } from "vitest";
+import { checkedMethod, loadValidator, transformFixture } from "./helpers.js";
+import {
+  v,
+  validateArgs,
+  wrapServerTarget,
+  type ServiceValidator,
+} from "../src/internal/core.js";
+
+function validator(body: string) {
+  return loadValidator(transformFixture(body, { target: "new Api()" }).code);
+}
+
+describe("extra arguments", () => {
+  it("ignores args beyond the declared parameters", () => {
+    const spec = checkedMethod(
+      validator(
+        `class Api extends RpcTarget {
+  greet(name: string): Promise<string> {
+    return null as any;
+  }
+}`,
+      ),
+      "greet",
+    );
+    expect(() =>
+      validateArgs(["bob", 123, { extra: true }], spec, "Api", "greet"),
+    ).not.toThrow();
+  });
+
+  it("still validates the declared parameters", () => {
+    const spec = checkedMethod(
+      validator(
+        `class Api extends RpcTarget {
+  greet(name: string): Promise<string> {
+    return null as any;
+  }
+}`,
+      ),
+      "greet",
+    );
+    expect(() => validateArgs([42, "ignored"], spec, "Api", "greet")).toThrow(
+      TypeError,
+    );
+  });
+
+  it("still validates extra args against a rest parameter", () => {
+    const spec = checkedMethod(
+      validator(
+        `class Api extends RpcTarget {
+  sum(label: string, ...values: number[]): Promise<number> {
+    return null as any;
+  }
+}`,
+      ),
+      "sum",
+    );
+    expect(() => validateArgs(["a", 1, 2], spec, "Api", "sum")).not.toThrow();
+    expect(() => validateArgs(["a", 1, "b"], spec, "Api", "sum")).toThrow(
+      TypeError,
+    );
+  });
+});
+
+// Ignoring an extra arg means the implementation never sees it: a rest
+// parameter or `arguments` would otherwise read a value no validator checked.
+describe("extra arguments reaching the implementation", () => {
+  function seen(validator: ServiceValidator, impl: (...a: unknown[]) => string) {
+    const target = { greet: impl, sum: impl };
+    return wrapServerTarget(target, validator) as Record<
+      string,
+      (...a: unknown[]) => string
+    >;
+  }
+
+  it("drops undeclared args before invoking the method", () => {
+    const rest: unknown[][] = [];
+    const api = seen(
+      { serviceName: "Api", methods: { greet: { args: [v.string], returns: v.string } } },
+      (...args: unknown[]) => {
+        rest.push(args);
+        return "ok";
+      },
+    );
+    expect(api.greet("bob", { steal: true })).toBe("ok");
+    expect(rest).toEqual([["bob"]]);
+  });
+
+  it("keeps extra args a rest parameter declares and validates", () => {
+    const rest: unknown[][] = [];
+    const api = seen(
+      {
+        serviceName: "Api",
+        methods: { sum: { args: [v.string], rest: v.number, returns: v.string } },
+      },
+      (...args: unknown[]) => {
+        rest.push(args);
+        return "ok";
+      },
+    );
+    expect(api.sum("a", 1, 2)).toBe("ok");
+    expect(rest).toEqual([["a", 1, 2]]);
+    expect(() => api.sum("a", 1, "b")).toThrow(TypeError);
+  });
+});

--- a/packages/capnweb-validate/src/internal/core.ts
+++ b/packages/capnweb-validate/src/internal/core.ts
@@ -543,7 +543,7 @@ export function validateArgs(
   }
   // Extra args beyond the declared parameter list are ignored, not refused: a
   // newer caller passing a parameter that this build's signature doesn't know
-  // about is normal schema evolution, and JS drops unused args anyway.
+  // about is normal schema evolution. wrapArgs drops them before the call.
 }
 
 const SERVER_PASSTHROUGH_METHODS = new Set([

--- a/packages/capnweb-validate/src/internal/core.ts
+++ b/packages/capnweb-validate/src/internal/core.ts
@@ -540,13 +540,10 @@ export function validateArgs(
     for (let i = specArgs.length; i < args.length; i++) {
       methodSpec.rest(args[i], [serviceName, prop, i]);
     }
-  } else if (args.length > specArgs.length) {
-    fail(
-      [serviceName, prop, specArgs.length],
-      "no extra argument",
-      args[specArgs.length]
-    );
   }
+  // Extra args beyond the declared parameter list are ignored, not refused: a
+  // newer caller passing a parameter that this build's signature doesn't know
+  // about is normal schema evolution, and JS drops unused args anyway.
 }
 
 const SERVER_PASSTHROUGH_METHODS = new Set([
@@ -669,6 +666,14 @@ function wrapArgs(
     for (let i = specArgs.length; i < args.length; i++) {
       wrapOne(i, methodSpec.rest);
     }
+    return next ?? args;
+  }
+  // Undeclared trailing args are validated by nothing, so drop them rather
+  // than hand them to the implementation: `greet(name, ...rest)` or
+  // `arguments` would otherwise see values no validator ever looked at. Only
+  // safe when the spec declares its params; a client-side spec omits `args`.
+  if (methodSpec.args && args.length > specArgs.length) {
+    return (next ?? args).slice(0, specArgs.length);
   }
   return next ?? args;
 }


### PR DESCRIPTION
`validateArgs` refused any call carrying more args than the method's declared parameter list. That breaks schema evolution: a caller built against a newer signature cannot pass a new parameter to a peer whose validator was generated from the old one, even though plain JS drops the unused arg.

Before:
```ts
// signature: greet(name: string)
stub.greet("bob", { locale: "en" });  // TypeError: refused Api.greet: no extra argument
```

After:
```ts
stub.greet("bob", { locale: "en" });  // extra arg ignored
```

Declared parameters are still validated, and a rest parameter still validates every extra arg.