### PR TITLE
Add support for sending `Set` over RPC

### DIFF
--- a/.changeset/serialize-set.md
+++ b/.changeset/serialize-set.md
@@ -1,0 +1,5 @@
+---
+"capnweb": minor
+---
+
+Support serializing `Set` objects over RPC.

--- a/.changeset/serialize-set.md
+++ b/.changeset/serialize-set.md
@@ -3,3 +3,5 @@
 ---
 
 Support serializing `Set` objects over RPC.
+
+A `Set` carries plain data only: promises, stubs, and `Blob`s are not allowed as elements, and sending one over a connection throws a `TypeError`.

--- a/README.md
+++ b/README.md
@@ -199,7 +199,7 @@ The following types can be passed over RPC (in arguments or return values), and 
 * Arrays
 * `bigint`
 * `Date`
-* `Set`
+* `Set`, except that an element may not be a promise, stub, or `Blob` (see below)
 * `ArrayBuffer`, `DataView`, and typed arrays
 * `Error` and its well-known subclasses
 * `Blob`
@@ -213,6 +213,7 @@ The following types are not supported as of this writing, but may be added in th
 The following are intentionally NOT supported:
 * Application-defined classes that do not extend `RpcTarget`.
 * Cyclic values. Messages are serialized strictly as trees (like JSON).
+* Promises, stubs, and `Blob`s as elements of a `Set`.
 
 ### `RpcTarget`
 

--- a/README.md
+++ b/README.md
@@ -199,6 +199,7 @@ The following types can be passed over RPC (in arguments or return values), and 
 * Arrays
 * `bigint`
 * `Date`
+* `Set`
 * `ArrayBuffer`, `DataView`, and typed arrays
 * `Error` and its well-known subclasses
 * `Blob`
@@ -206,7 +207,7 @@ The following types can be passed over RPC (in arguments or return values), and 
 * `Headers`, `Request`, and `Response` from the Fetch API.
 
 The following types are not supported as of this writing, but may be added in the future:
-* `Map` and `Set`
+* `Map`
 * `RegExp`
 
 The following are intentionally NOT supported:

--- a/__tests__/index.test.ts
+++ b/__tests__/index.test.ts
@@ -27,6 +27,8 @@ let SERIALIZE_TEST_CASES: Record<string, unknown> = {
   '{"foo":[[123]]}': {foo: [123]},
   '{"foo":[[123]],"bar":[[456,789]]}': {foo: [123], bar: [456, 789]},
 
+  '["set",[1,2,"abc",[[123]]]]': new Set([1, 2, "abc", [123]]),
+
   '["bigint","123"]': 123n,
   '["date",1234]': new Date(1234),
   '["bytes","aGVsbG8h"]': new TextEncoder().encode("hello!"),
@@ -1570,6 +1572,117 @@ describe("promise pipelining", () => {
 
     await expect(() => promise).rejects.toThrow("test error");
     await expect(() => promise2).rejects.toThrow("test error");
+  });
+});
+
+describe("promises inside a Set", () => {
+  // A Set has no addressable positions, but delivery resolves a located promise by assigning
+  // `parent[property] = value`. These tests pin the behavior of the temporary setter that makes
+  // that work, on both the wire path (Evaluator) and the local path (RpcPayload.deepCopy).
+  class SetTarget extends RpcTarget {
+    square(i: number) {
+      return i * i;
+    }
+
+    // Reports what actually arrived. Deliberately does not await the elements: an unresolved
+    // promise is still thenable, so awaiting would hide a failure to substitute it.
+    inspect(container: Set<unknown>) {
+      return {
+        isSet: container instanceof Set,
+        elements: [...container].map(element => {
+          // RPC stubs and promises are callable, so typeof reports "function", not "object".
+          let objectLike = element !== null &&
+              (typeof element === "object" || typeof element === "function");
+          return objectLike && typeof (<any>element).then === "function"
+              ? "<unresolved>" : element;
+        }),
+        // Anything here is a resolved value that was written onto the Set as a property instead
+        // of replacing the element it belongs to.
+        strayProps: Object.getOwnPropertyNames(container),
+      };
+    }
+
+    // Blobs are always delivered through the promise machinery, so this exercises the same path
+    // in the returning direction without any pipelining on the caller's part.
+    makeBlobSet() {
+      return new Set([new Blob(["first"]), new Blob(["second"])]);
+    }
+  }
+
+  it("substitutes a promise sent inside a Set", async () => {
+    await using harness = new TestHarness(new SetTarget());
+    let stub = harness.stub;
+    using promise = stub.square(3);
+
+    let result = await stub.inspect(new Set<unknown>(["alpha", promise, "omega"]));
+
+    expect(result.isSet).toBe(true);
+    expect(result.elements).toStrictEqual(["alpha", 9, "omega"]);
+    expect(result.strayProps).toStrictEqual([]);
+  });
+
+  it("substitutes multiple promises at their own positions", async () => {
+    await using harness = new TestHarness(new SetTarget());
+    let stub = harness.stub;
+    using first = stub.square(3);
+    using second = stub.square(4);
+
+    // Every element must get a distinct property. Sharing one would make both writes target the
+    // same slot, losing all but the last.
+    let result = await stub.inspect(new Set<unknown>(["a", first, "b", second, "c"]));
+
+    expect(result.elements).toStrictEqual(["a", 9, "b", 16, "c"]);
+    expect(result.strayProps).toStrictEqual([]);
+  });
+
+  it("leaves no residue when a promise is nested inside a Set element", async () => {
+    await using harness = new TestHarness(new SetTarget());
+    let stub = harness.stub;
+    using promise = stub.square(4);
+
+    // Here the promise's parent is the inner object, not the Set, so the Set needs no setter.
+    let result = await stub.inspect(new Set<unknown>([{value: promise}]));
+
+    expect(result.elements).toStrictEqual([{value: 16}]);
+    expect(result.strayProps).toStrictEqual([]);
+  });
+
+  it("collapses a resolution that equals an existing element", async () => {
+    await using harness = new TestHarness(new SetTarget());
+    let stub = harness.stub;
+    using promise = stub.square(3);
+
+    // Rebuilding the Set re-applies Set semantics, so the duplicate 9 drops out.
+    let result = await stub.inspect(new Set<unknown>([9, promise, "tail"]));
+
+    expect(result.elements).toStrictEqual([9, "tail"]);
+    expect(result.strayProps).toStrictEqual([]);
+  });
+
+  it("substitutes Blobs in a Set returned to the caller", async () => {
+    await using harness = new TestHarness(new SetTarget());
+
+    let received = await harness.stub.makeBlobSet();
+
+    expect(received).toBeInstanceOf(Set);
+    expect(Object.getOwnPropertyNames(received)).toStrictEqual([]);
+    expect(await Promise.all([...received].map(blob => blob.text())))
+        .toStrictEqual(["first", "second"]);
+  });
+
+  it("substitutes a promise in a Set passed to a local stub", async () => {
+    using stub = new RpcStub(new SetTarget());
+    using promise = stub.square(3);
+    let source = new Set<unknown>(["alpha", promise, "omega"]);
+
+    let result = await stub.inspect(source);
+
+    expect(result.elements).toStrictEqual(["alpha", 9, "omega"]);
+    expect(result.strayProps).toStrictEqual([]);
+
+    // deepCopy() must fix up its copy, not the caller's Set.
+    expect([...source][1]).toBe(promise);
+    expect(Object.getOwnPropertyNames(source)).toStrictEqual([]);
   });
 });
 

--- a/__tests__/index.test.ts
+++ b/__tests__/index.test.ts
@@ -1575,10 +1575,22 @@ describe("promise pipelining", () => {
   });
 });
 
-describe("promises inside a Set", () => {
-  // A Set has no addressable positions, but delivery resolves a located promise by assigning
-  // `parent[property] = value`. These tests pin the behavior of the temporary setter that makes
-  // that work, on both the wire path (Evaluator) and the local path (RpcPayload.deepCopy).
+describe("promises, stubs and Blobs inside a Set", () => {
+  // A Set carries plain data only: no promises, stubs or Blobs as elements. A promise or Blob is
+  // delivered by substituting the value into its parent, i.e. `parent[property] = value`, and a Set
+  // has no property that names an element. Rather than mutate the Set behind the application's
+  // back, we reject it. Stubs are excluded along with them so a Set behaves the same in both
+  // directions. These tests pin that down on the send path (Devaluator), the local path
+  // (RpcPayload.deepCopy), and the receive path (Evaluator).
+  //
+  // Each path converts the element first and then checks what came back, instead of inspecting the
+  // element's type up front. That's why a Blob or stub is rejected over a connection but allowed on
+  // a local call, where nothing is encoded.
+  const PROMISE_ERROR = "Cannot serialize a promise as an element of a Set";
+  const BLOB_ERROR = "Cannot serialize a Blob as an element of a Set";
+  const DESERIALIZE_ERROR = "Cannot deserialize a stub or promise as an element of a Set";
+  const STUB_ERROR = "Cannot serialize a stub as an element of a Set";
+
   class SetTarget extends RpcTarget {
     square(i: number) {
       return i * i;
@@ -1602,87 +1614,167 @@ describe("promises inside a Set", () => {
       };
     }
 
-    // Blobs are always delivered through the promise machinery, so this exercises the same path
-    // in the returning direction without any pipelining on the caller's part.
+    // Sending a Blob over a connection means streaming it, so it arrives behind a promise and hits
+    // the same restriction, even though the application never created a promise.
     makeBlobSet() {
-      return new Set([new Blob(["first"]), new Blob(["second"])]);
+      return new Set([new Blob(["first"])]);
+    }
+
+    // Hands the stub straight back inside a Set. Since the caller is the one that exported it, the
+    // caller's Evaluator sees the element as an ["import", id] expression.
+    bounce(stub: any) {
+      return new Set([stub.dup()]);
+    }
+
+    makeCounter(i: number) {
+      return new Counter(i);
+    }
+
+    // Stubs are passed by reference rather than substituted, so they remain legal elements.
+    async incrementAll(container: Set<unknown>) {
+      let results: number[] = [];
+      for (let element of container) {
+        results.push(await (<any>element).increment(1));
+      }
+      return {isSet: container instanceof Set, results};
     }
   }
 
-  it("substitutes a promise sent inside a Set", async () => {
+  it("rejects a promise sent inside a Set", async () => {
     await using harness = new TestHarness(new SetTarget());
     let stub = harness.stub;
     using promise = stub.square(3);
 
-    let result = await stub.inspect(new Set<unknown>(["alpha", promise, "omega"]));
+    // Thrown synchronously at the call site, like any other unserializable argument.
+    expect(() => stub.inspect(new Set<unknown>(["alpha", promise, "omega"])))
+        .toThrow(PROMISE_ERROR);
 
-    expect(result.isSet).toBe(true);
-    expect(result.elements).toStrictEqual(["alpha", 9, "omega"]);
-    expect(result.strayProps).toStrictEqual([]);
+    // The failed call must not have poisoned the session.
+    expect(await stub.inspect(new Set<unknown>(["alpha", "omega"])))
+        .toStrictEqual({isSet: true, elements: ["alpha", "omega"], strayProps: []});
   });
 
-  it("substitutes multiple promises at their own positions", async () => {
+  it("rejects a promise in a Set passed to a local stub", async () => {
+    using stub = new RpcStub(new SetTarget());
+    using promise = stub.square(3);
+    let source = new Set<unknown>(["alpha", promise, "omega"]);
+
+    // The local path copies at delivery time, so this surfaces as a rejection.
+    await expect(() => stub.inspect(source)).rejects.toThrow(PROMISE_ERROR);
+
+    // The caller's Set is left exactly as it was.
+    expect([...source]).toStrictEqual(["alpha", promise, "omega"]);
+    expect(Object.getOwnPropertyNames(source)).toStrictEqual([]);
+  });
+
+  it("rejects a Blob sent inside a Set", async () => {
     await using harness = new TestHarness(new SetTarget());
-    let stub = harness.stub;
-    using first = stub.square(3);
-    using second = stub.square(4);
 
-    // Every element must get a distinct property. Sharing one would make both writes target the
-    // same slot, losing all but the last.
-    let result = await stub.inspect(new Set<unknown>(["a", first, "b", second, "c"]));
+    // Caught while encoding, before the Blob's pipe is created. The harness checks at the end of
+    // the test that no import or export leaked, which is what creating the pipe and then throwing
+    // would do.
+    expect(() => harness.stub.inspect(new Set<unknown>([new Blob(["hello"])]))).toThrow(BLOB_ERROR);
+  });
 
-    expect(result.elements).toStrictEqual(["a", 9, "b", 16, "c"]);
+  it("rejects a Blob in a Set returned to the caller", async () => {
+    await using harness = new TestHarness(new SetTarget());
+
+    // Caught by the server as it serializes its result. Note the arrow function: an RpcPromise is
+    // callable, so passing one to `expect(...).rejects` directly would make vitest invoke it.
+    await expect(() => harness.stub.makeBlobSet()).rejects.toThrow(BLOB_ERROR);
+  });
+
+  it("rejects a Set containing a Blob in plain serialize()", () => {
+    expect(() => serialize(new Set([new Blob(["hello"])]))).toThrow(BLOB_ERROR);
+  });
+
+  it("accepts a Blob in a Set passed to a local stub", async () => {
+    using stub = new RpcStub(new SetTarget());
+    let blob = new Blob(["hello"]);
+
+    // A same-process call streams nothing. The app receives this very Blob, so no promise is
+    // involved and there is nothing to substitute. Only a Blob crossing a connection is a problem.
+    let result = await stub.inspect(new Set<unknown>([blob]));
+
+    expect(result.elements).toStrictEqual([blob]);
     expect(result.strayProps).toStrictEqual([]);
   });
 
-  it("leaves no residue when a promise is nested inside a Set element", async () => {
+  it("accepts a promise nested inside a Set element", async () => {
     await using harness = new TestHarness(new SetTarget());
     let stub = harness.stub;
     using promise = stub.square(4);
 
-    // Here the promise's parent is the inner object, not the Set, so the Set needs no setter.
+    // Only a promise that is *itself* an element is a problem. Here the promise's parent is the
+    // inner object, which has a property to write the resolution to.
     let result = await stub.inspect(new Set<unknown>([{value: promise}]));
 
     expect(result.elements).toStrictEqual([{value: 16}]);
     expect(result.strayProps).toStrictEqual([]);
   });
 
-  it("collapses a resolution that equals an existing element", async () => {
+  it("rejects a stub sent inside a Set", async () => {
     await using harness = new TestHarness(new SetTarget());
-    let stub = harness.stub;
-    using promise = stub.square(3);
+    using counter = new RpcStub(new Counter(5));
 
-    // Rebuilding the Set re-applies Set semantics, so the duplicate 9 drops out.
-    let result = await stub.inspect(new Set<unknown>([9, promise, "tail"]));
-
-    expect(result.elements).toStrictEqual([9, "tail"]);
-    expect(result.strayProps).toStrictEqual([]);
+    // A Set holds plain data only, so a stub the sender owns is out too. It encodes as ["export"].
+    expect(() => harness.stub.incrementAll(new Set<unknown>([counter]))).toThrow(STUB_ERROR);
   });
 
-  it("substitutes Blobs in a Set returned to the caller", async () => {
+  it("rejects a stub pointing back at the peer inside a Set", async () => {
     await using harness = new TestHarness(new SetTarget());
 
-    let received = await harness.stub.makeBlobSet();
+    // The other encoding of a stub: this one is the peer's own capability, so it goes out as
+    // ["import"] rather than ["export"].
+    using counter = await harness.stub.makeCounter(5);
 
-    expect(received).toBeInstanceOf(Set);
-    expect(Object.getOwnPropertyNames(received)).toStrictEqual([]);
-    expect(await Promise.all([...received].map(blob => blob.text())))
-        .toStrictEqual(["first", "second"]);
+    expect(() => harness.stub.incrementAll(new Set<unknown>([counter]))).toThrow(STUB_ERROR);
   });
 
-  it("substitutes a promise in a Set passed to a local stub", async () => {
+  it("rejects a stub in a Set returned to the caller", async () => {
+    await using harness = new TestHarness(new SetTarget());
+    using counter = new RpcStub(new Counter(5));
+
+    // Caught by the server as it serializes its result, and reported as the call's rejection.
+    await expect(() => harness.stub.bounce(counter)).rejects.toThrow(STUB_ERROR);
+  });
+
+  it("accepts a stub in a Set passed to a local stub", async () => {
     using stub = new RpcStub(new SetTarget());
+    using counter = new RpcStub(new Counter(5));
+
+    // Same leniency as a Blob on this path: nothing is encoded, so the app just gets the stub.
+    expect(await stub.incrementAll(new Set<unknown>([counter])))
+        .toStrictEqual({isSet: true, results: [6]});
+  });
+
+  it("rejects a promise arriving inside a Set from a peer", async () => {
+    // The sender-side check above means a well-behaved peer never produces this message, so we
+    // have to forge it: rewrite the outgoing call so the argument that was an array containing a
+    // pipelined promise becomes a *Set* containing that same promise. This exercises the
+    // receiver's own guard, which is what stops a hostile or buggy peer from corrupting a Set.
+    //
+    // Not using `await using`: the forged message breaks the session, so the harness's
+    // end-of-test "everything was disposed" check does not apply.
+    let harness = new TestHarness(new SetTarget());
+    let stub = harness.stub;
+
+    let origSend = harness.clientTransport.send;
+    harness.clientTransport.send = function(message: string) {
+      let rewritten = JSON.stringify(JSON.parse(message), function(_key, value) {
+        // Match the escaped-array encoding `[[<element>]]` and re-encode it as `["set", [...]]`.
+        if (value instanceof Array && value.length === 1 &&
+            value[0] instanceof Array && value[0].length === 1 &&
+            value[0][0] instanceof Array && value[0][0][0] === "pipeline") {
+          return ["set", value[0]];
+        }
+        return value;
+      });
+      return origSend.call(this, rewritten);
+    };
+
     using promise = stub.square(3);
-    let source = new Set<unknown>(["alpha", promise, "omega"]);
-
-    let result = await stub.inspect(source);
-
-    expect(result.elements).toStrictEqual(["alpha", 9, "omega"]);
-    expect(result.strayProps).toStrictEqual([]);
-
-    // deepCopy() must fix up its copy, not the caller's Set.
-    expect([...source][1]).toBe(promise);
-    expect(Object.getOwnPropertyNames(source)).toStrictEqual([]);
+    await expect(() => stub.inspect([promise] as any)).rejects.toThrow(DESERIALIZE_ERROR);
   });
 });
 

--- a/packages/capnweb-validate/src/internal/core.ts
+++ b/packages/capnweb-validate/src/internal/core.ts
@@ -75,6 +75,7 @@ type BaseType =
   | bigint
   | string
   | Date
+  | Set<unknown>
   | Error
   | RegExp
   | Blob

--- a/protocol.md
+++ b/protocol.md
@@ -195,6 +195,8 @@ A JavaScript `Date` value. The number represents milliseconds since the Unix epo
 
 A JavaScript `Set` value. `elements` is an array of the set elements.
 
+An element must not be a promise, a stub, or a blob.
+
 `["error", type, message, stack?, props?]`
 
 A JavaScript `Error` value. `type` is the name of the specific well-known `Error` subclass, e.g. "TypeError". `message` is a string containing the error message. `stack` may optionally contain the stack trace, though by default stacks will be redacted for security reasons.

--- a/protocol.md
+++ b/protocol.md
@@ -191,6 +191,10 @@ bound parsing cost.
 
 A JavaScript `Date` value. The number represents milliseconds since the Unix epoch.
 
+`["set", elements]`
+
+A JavaScript `Set` value. `elements` is an array of the set elements.
+
 `["error", type, message, stack?, props?]`
 
 A JavaScript `Error` value. `type` is the name of the specific well-known `Error` subclass, e.g. "TypeError". `message` is a string containing the error message. `stack` may optionally contain the stack trace, though by default stacks will be redacted for security reasons.

--- a/src/core.ts
+++ b/src/core.ts
@@ -37,7 +37,7 @@ export let RpcTarget = workersModule ? workersModule.RpcTarget : class {};
 
 export type PropertyPath = (string | number)[];
 
-type TypeForRpc = "unsupported" | "primitive" | "object" | "function" | "array" | "date" |
+type TypeForRpc = "unsupported" | "primitive" | "object" | "function" | "array" | "date" | "set" |
     "bigint" | "bytes" | "blob" | "stub" | "rpc-promise" | "rpc-target" | "rpc-thenable" |
     "error" | "undefined" | "writable" | "readable" | "headers" | "request" | "response";
 
@@ -92,6 +92,9 @@ export function typeForRpc(value: unknown): TypeForRpc {
 
     case Date.prototype:
       return "date";
+
+    case Set.prototype:
+      return "set";
 
     case Uint8Array.prototype:
     case BUFFER_PROTOTYPE:
@@ -626,6 +629,28 @@ export function unwrapStubAndPath(stub: RpcStub): {hook: StubHook, pathIfPromise
   return stub[RAW_STUB];
 }
 
+// RpcPromise elements are set using property access on the parent. 
+// 
+// To make this work for `Set`, this function defines a one-time use setter that inserts the 
+// resolved value in the correct order and rebuilds the set.
+//
+// The `property` must be unique for each element.
+export function defineSetPromiseSlot(set: Set<unknown>, property: string, placeholder: unknown) {
+  if (!(placeholder instanceof RpcPromise)) return;
+  Object.defineProperty(set, property, {
+    configurable: true, enumerable: false,
+    set(resolved: unknown) {
+      let elms = [...set];
+      let ri = elms.indexOf(placeholder);
+      delete (set as any)[property]
+      set.clear()
+      for (let i = 0; i < elms.length; i++) {
+        set.add(i === ri ? resolved : elms[i]);
+      }
+    }
+  });
+}
+
 // Given a promise stub (still wrapped in a Proxy), pull the remote promise and deliver the
 // payload. This is a helper used to implement the then/catch/finally methods of RpcPromise.
 async function pullPromise(promise: RpcPromise): Promise<unknown> {
@@ -974,9 +999,24 @@ export class RpcPayload {
         // parent.
         let array = <Array<unknown>>value;
         let len = array.length;
-        let result = new Array(len);
+        let result = new Array(len);        
         for (let i = 0; i < len; i++) {
           result[i] = this.deepCopy(array[i], array, i, result, dupStubs, owner);
+        }
+        return result;
+      }
+
+      case "set": {
+        // We have to construct the new set first, then fill it in, so we can pass it as the
+        // parent.
+        let set = <Set<unknown>>value;
+        let result = new Set();
+        let counter = 0;
+        for (let val of set) {
+          let key = `${counter++}`;
+          let copy = this.deepCopy(val, set, key, result, dupStubs, owner);
+          defineSetPromiseSlot(result, key, copy);            
+          result.add(copy)
         }
         return result;
       }
@@ -1357,6 +1397,14 @@ export class RpcPayload {
         return;
       }
 
+      case "set": {
+        let set = <Set<unknown>>value;
+        for (let element of <Set<unknown>>value) {
+          this.disposeImpl(element, set)
+        }
+        return;
+      }
+
       case "object": {
         let object = <Record<string, unknown>>value;
         for (let i in object) {
@@ -1503,6 +1551,14 @@ export class RpcPayload {
         return;
       }
 
+      case "set": {
+        let set = <Set<unknown>>value;
+        for (let element of set) {
+          this.ignoreUnhandledRejectionsImpl(element);
+        }
+        return;
+      }
+
       case "object": {
         let object = <Record<string, unknown>>value;
         for (let i in object) {
@@ -1641,6 +1697,7 @@ function followPath(value: unknown, parent: object | undefined,
       case "bytes":
       case "blob":
       case "date":
+      case "set":
       case "error":
       case "headers":
       case "request":

--- a/src/core.ts
+++ b/src/core.ts
@@ -629,28 +629,6 @@ export function unwrapStubAndPath(stub: RpcStub): {hook: StubHook, pathIfPromise
   return stub[RAW_STUB];
 }
 
-// RpcPromise elements are set using property access on the parent.
-//
-// To make this work for `Set`, this function defines a one-time-use setter that inserts the
-// resolved value in the correct order and rebuilds the set.
-//
-// The `property` must be unique for each element.
-export function defineSetPromiseSlot(set: Set<unknown>, property: string, placeholder: unknown) {
-  if (!(placeholder instanceof RpcPromise)) return;
-  Object.defineProperty(set, property, {
-    configurable: true, enumerable: false,
-    set(resolved: unknown) {
-      let elms = [...set];
-      let ri = elms.indexOf(placeholder);
-      delete (set as any)[property];
-      set.clear();
-      for (let i = 0; i < elms.length; i++) {
-        set.add(i === ri ? resolved : elms[i]);
-      }
-    }
-  });
-}
-
 // Given a promise stub (still wrapped in a Proxy), pull the remote promise and deliver the
 // payload. This is a helper used to implement the then/catch/finally methods of RpcPromise.
 async function pullPromise(promise: RpcPromise): Promise<unknown> {
@@ -1011,11 +989,14 @@ export class RpcPayload {
         // parent.
         let set = <Set<unknown>>value;
         let result = new Set();
-        let counter = 0;
+        let index = 0;
         for (let val of set) {
-          let key = `${counter++}`;
-          let copy = this.deepCopy(val, set, key, result, dupStubs, owner);
-          defineSetPromiseSlot(result, key, copy);
+          let copy = this.deepCopy(val, set, index++, result, dupStubs, owner);
+          if (copy instanceof RpcPromise) {
+            throw new TypeError(
+                "Cannot serialize a promise as an element of a Set. Await the value before " +
+                "adding it to the Set.");
+          }
           result.add(copy);
         }
         return result;

--- a/src/core.ts
+++ b/src/core.ts
@@ -642,8 +642,8 @@ export function defineSetPromiseSlot(set: Set<unknown>, property: string, placeh
     set(resolved: unknown) {
       let elms = [...set];
       let ri = elms.indexOf(placeholder);
-      delete (set as any)[property]
-      set.clear()
+      delete (set as any)[property];
+      set.clear();
       for (let i = 0; i < elms.length; i++) {
         set.add(i === ri ? resolved : elms[i]);
       }

--- a/src/core.ts
+++ b/src/core.ts
@@ -629,9 +629,9 @@ export function unwrapStubAndPath(stub: RpcStub): {hook: StubHook, pathIfPromise
   return stub[RAW_STUB];
 }
 
-// RpcPromise elements are set using property access on the parent. 
-// 
-// To make this work for `Set`, this function defines a one-time use setter that inserts the 
+// RpcPromise elements are set using property access on the parent.
+//
+// To make this work for `Set`, this function defines a one-time-use setter that inserts the
 // resolved value in the correct order and rebuilds the set.
 //
 // The `property` must be unique for each element.
@@ -999,7 +999,7 @@ export class RpcPayload {
         // parent.
         let array = <Array<unknown>>value;
         let len = array.length;
-        let result = new Array(len);        
+        let result = new Array(len);
         for (let i = 0; i < len; i++) {
           result[i] = this.deepCopy(array[i], array, i, result, dupStubs, owner);
         }
@@ -1015,7 +1015,8 @@ export class RpcPayload {
         for (let val of set) {
           let key = `${counter++}`;
           let copy = this.deepCopy(val, set, key, result, dupStubs, owner);
-          defineSetPromiseSlot(result, key, copy);            
+          defineSetPromiseSlot(result, key, copy);
+          result.add(copy);
           result.add(copy)
         }
         return result;
@@ -1400,7 +1401,8 @@ export class RpcPayload {
       case "set": {
         let set = <Set<unknown>>value;
         for (let element of <Set<unknown>>value) {
-          this.disposeImpl(element, set)
+        for (let element of set) {
+          this.disposeImpl(element, set);
         }
         return;
       }

--- a/src/core.ts
+++ b/src/core.ts
@@ -1017,7 +1017,6 @@ export class RpcPayload {
           let copy = this.deepCopy(val, set, key, result, dupStubs, owner);
           defineSetPromiseSlot(result, key, copy);
           result.add(copy);
-          result.add(copy)
         }
         return result;
       }
@@ -1400,7 +1399,6 @@ export class RpcPayload {
 
       case "set": {
         let set = <Set<unknown>>value;
-        for (let element of <Set<unknown>>value) {
         for (let element of set) {
           this.disposeImpl(element, set);
         }

--- a/src/serialize.ts
+++ b/src/serialize.ts
@@ -863,9 +863,6 @@ export class Evaluator {
             return set;
           }
           break;
-            return set;
-          }
-          break;
         case "bytes": {
           let bytes: Uint8Array;
           // At jsonCompatibleWithBytes/structuredClonable level, bytes may already be raw.

--- a/src/serialize.ts
+++ b/src/serialize.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT license found in the LICENSE.txt file or at:
 //     https://opensource.org/license/mit
 
-import { StubHook, RpcPayload, typeForRpc, RpcStub, RpcPromise, LocatedPromise, RpcTarget, unwrapStubAndPath, streamImpl, PromiseStubHook, PayloadStubHook } from "./core.js";
+import { StubHook, RpcPayload, typeForRpc, RpcStub, RpcPromise, LocatedPromise, RpcTarget, unwrapStubAndPath, streamImpl, PromiseStubHook, PayloadStubHook, defineSetPromiseSlot } from "./core.js";
 
 export type ImportId = number;
 export type ExportId = number;
@@ -317,6 +317,15 @@ export class Devaluator {
         }
         // Wrap literal arrays in an outer one-element array, to "escape" them.
         return [result];
+      }
+
+      case "set": {
+        let set = <Set<unknown>>value;        
+        let elements: unknown[] = [];
+        for (let element of set) {          
+          elements.push(this.devaluateImpl(element, set, depth + 1))
+        }
+        return ["set", elements];
       }
 
       case "bigint":
@@ -839,6 +848,19 @@ export class Evaluator {
           }
           if (typeof value[1] == "number") {
             return new Date(value[1]);
+          }
+          break;
+        case "set":
+          if (value.length === 2 && value[1] instanceof Array) {
+            let set = new Set();
+            let counter = 0;
+            for (let element of value[1]) {
+              let key = `${counter++}`
+              let copy = this.evaluateImpl(element, set, key, depth + 1)
+              defineSetPromiseSlot(set, key, copy)
+              set.add(copy);
+            }
+            return set;
           }
           break;
         case "bytes": {

--- a/src/serialize.ts
+++ b/src/serialize.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT license found in the LICENSE.txt file or at:
 //     https://opensource.org/license/mit
 
-import { StubHook, RpcPayload, typeForRpc, RpcStub, RpcPromise, LocatedPromise, RpcTarget, unwrapStubAndPath, streamImpl, PromiseStubHook, PayloadStubHook, defineSetPromiseSlot } from "./core.js";
+import { StubHook, RpcPayload, typeForRpc, RpcStub, RpcPromise, LocatedPromise, RpcTarget, unwrapStubAndPath, streamImpl, PromiseStubHook, PayloadStubHook } from "./core.js";
 
 export type ImportId = number;
 export type ExportId = number;
@@ -323,7 +323,27 @@ export class Devaluator {
         let set = <Set<unknown>>value;
         let elements: unknown[] = [];
         for (let element of set) {
-          elements.push(this.devaluateImpl(element, set, depth + 1));
+          let encoded = this.devaluateImpl(element, set, depth + 1);
+
+          // A Set holds plain data only: no promises, stubs or blobs (see protocol.md). Blobs are
+          // rejected by the `blob` case, which has to refuse one before it starts a pipe.
+          if (encoded instanceof Array && typeof encoded[0] === "string") {
+            switch (encoded[0]) {
+              case "promise":
+              case "pipeline":
+              case "remap":
+                throw new TypeError(
+                    "Cannot serialize a promise as an element of a Set. Await the value before " +
+                    "adding it to the Set.");
+
+              case "export":
+              case "import":
+                throw new TypeError(
+                    "Cannot serialize a stub as an element of a Set.");
+            }
+          }
+
+          elements.push(encoded);
         }
         return ["set", elements];
       }
@@ -522,6 +542,14 @@ export class Devaluator {
         // synchronously, and we MUST serialize the message synchronously. Hence, we have no choice
         // but to use streaming even for small blobs.
         let blob = value as Blob;
+
+        // The receiver must buffer the whole stream before it can construct the Blob, so it
+        // delivers the Blob as a promise. Set doesn't support a promise. To avoid the creation of a
+        // pipe, we reject it here.
+        if (parent instanceof Set) {
+          throw new TypeError("Cannot serialize a Blob as an element of a Set.");
+        }
+
         let readable = blob.stream();
         let hook = streamImpl.createReadableStreamHook(readable);
         let importId = this.exporter.createPipe(readable, hook);
@@ -852,12 +880,18 @@ export class Evaluator {
           break;
         case "set":
           if (value.length === 2 && value[1] instanceof Array) {
+            let elements = value[1];
             let set = new Set();
-            let counter = 0;
-            for (let element of value[1]) {
-              let key = `${counter++}`;
-              let copy = this.evaluateImpl(element, set, key, depth + 1);
-              defineSetPromiseSlot(set, key, copy);
+            for (let i = 0; i < elements.length; i++) {
+              // A Set holds plain data only: no promises, stubs or blobs (see protocol.md). All
+              // three evaluate to an RpcStub, since RpcPromise extends it and a ["blob"] arrives as
+              // a promise for the streamed bytes. Nothing reads the `i` we pass as the property,
+              // but it stays a real index because "response" and "blob" elements pass the pair
+              // down to their contents.
+              let copy = this.evaluateImpl(elements[i], set, i, depth + 1);
+              if (copy instanceof RpcStub) {
+                throw new TypeError("Cannot deserialize a stub or promise as an element of a Set.");
+              }
               set.add(copy);
             }
             return set;

--- a/src/serialize.ts
+++ b/src/serialize.ts
@@ -320,10 +320,10 @@ export class Devaluator {
       }
 
       case "set": {
-        let set = <Set<unknown>>value;        
+        let set = <Set<unknown>>value;
         let elements: unknown[] = [];
-        for (let element of set) {          
-          elements.push(this.devaluateImpl(element, set, depth + 1))
+        for (let element of set) {
+          elements.push(this.devaluateImpl(element, set, depth + 1));
         }
         return ["set", elements];
       }
@@ -855,11 +855,14 @@ export class Evaluator {
             let set = new Set();
             let counter = 0;
             for (let element of value[1]) {
-              let key = `${counter++}`
-              let copy = this.evaluateImpl(element, set, key, depth + 1)
-              defineSetPromiseSlot(set, key, copy)
+              let key = `${counter++}`;
+              let copy = this.evaluateImpl(element, set, key, depth + 1);
+              defineSetPromiseSlot(set, key, copy);
               set.add(copy);
             }
+            return set;
+          }
+          break;
             return set;
           }
           break;

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -85,6 +85,7 @@ type BaseType =
   | ArrayBuffer
   | DataView
   | Date
+  | Set<any>
   | Error
   | RegExp
   | Blob


### PR DESCRIPTION
Adds serialization support for `Set`. Doesn't special case `.map()` like we do for arrays, uses the default. I think we don't need it is because `Set` itself doesn't have one, so it is not expected as much as it is on an `Array`.

This does handle lazy values that are part of a set. Again, can't think of a use case but using a `Blob` as an element of `Set` is technically valid and also using an `RpcPromise` that you get back as part of the `Set`, so this implementation handles such cases. It handles it by not moving away from `LocatedPromise` which expects a parent and property accessor to replace the placeholder promise with the resolved value.

We could refactor the code to avoid the temporary setter but that felt like a bigger change, so once this and `Map` implementation merges we can revisit that.

If we want to revisit `.map` over set elements, I think we should block `.map` support for `Set`

Closes #221 