### PR TITLE
Support `Map` over the RPC

### DIFF
--- a/.changeset/serialize-map.md
+++ b/.changeset/serialize-map.md
@@ -1,0 +1,5 @@
+---
+"capnweb": minor
+---
+
+Support serializing `Map` objects over RPC.

--- a/README.md
+++ b/README.md
@@ -199,6 +199,7 @@ The following types can be passed over RPC (in arguments or return values), and 
 * Arrays
 * `bigint`
 * `Date`
+* `Map`
 * `ArrayBuffer`, `DataView`, and typed arrays
 * `Error` and its well-known subclasses
 * `Blob`
@@ -206,7 +207,7 @@ The following types can be passed over RPC (in arguments or return values), and 
 * `Headers`, `Request`, and `Response` from the Fetch API.
 
 The following types are not supported as of this writing, but may be added in the future:
-* `Map` and `Set`
+* `Set`
 * `RegExp`
 
 The following are intentionally NOT supported:

--- a/__tests__/index.test.ts
+++ b/__tests__/index.test.ts
@@ -27,6 +27,10 @@ let SERIALIZE_TEST_CASES: Record<string, unknown> = {
   '{"foo":[[123]]}': {foo: [123]},
   '{"foo":[[123]],"bar":[[456,789]]}': {foo: [123], bar: [456, 789]},
 
+  '["map",[]]': new Map(),
+  '["map",[[1,"one"],["two",[[2]]],[["date",1234],{"nested":true}]]]':
+      new Map<unknown, unknown>([[1, "one"], ["two", [2]], [new Date(1234), {nested: true}]]),
+
   '["bigint","123"]': 123n,
   '["date",1234]': new Date(1234),
   '["bytes","aGVsbG8h"]': new TextEncoder().encode("hello!"),
@@ -132,6 +136,8 @@ describe("simple serialization", () => {
     expect(() => deserialize('["unknown_type", "param"]')).toThrowError();
     expect(() => deserialize('["date"]')).toThrowError(); // missing timestamp
     expect(() => deserialize('["error"]')).toThrowError(); // missing type and message
+    expect(() => deserialize('["map",[[1]]]')).toThrowError(); // entry isn't a key/value pair
+    expect(() => deserialize('["map",[1]]')).toThrowError(); // entry isn't an array
   })
 
   it("can serialize large Uint8Array without stack overflow", () => {
@@ -1570,6 +1576,153 @@ describe("promise pipelining", () => {
 
     await expect(() => promise).rejects.toThrow("test error");
     await expect(() => promise2).rejects.toThrow("test error");
+  });
+});
+
+describe("promises inside a Map", () => {
+  // Like a Set, a Map has no addressable positions, but delivery resolves a located promise by
+  // assigning `parent[property] = value`. Both keys and values may be promises, so each entry
+  // needs two distinct slots. These tests pin the behavior of those temporary setters on both the
+  // wire path (Evaluator) and the local path (RpcPayload.deepCopy).
+  class MapTarget extends RpcTarget {
+    square(i: number) {
+      return i * i;
+    }
+
+    // Reports what actually arrived. Deliberately does not await the entries: an unresolved
+    // promise is still thenable, so awaiting would hide a failure to substitute it.
+    inspect(container: Map<unknown, unknown>) {
+      let render = (value: unknown) => {
+        // RPC stubs and promises are callable, so typeof reports "function", not "object".
+        let objectLike = value !== null &&
+            (typeof value === "object" || typeof value === "function");
+        return objectLike && typeof (<any>value).then === "function" ? "<unresolved>" : value;
+      };
+      return {
+        isMap: container instanceof Map,
+        entries: [...container].map(([key, value]) => [render(key), render(value)]),
+        // Anything here is a resolved value that was written onto the Map as a property instead
+        // of replacing the key or value it belongs to.
+        strayProps: Object.getOwnPropertyNames(container),
+      };
+    }
+
+    // Blobs are always delivered through the promise machinery, so this exercises the same path
+    // in the returning direction without any pipelining on the caller's part.
+    makeBlobMap() {
+      return new Map([[new Blob(["key"]), new Blob(["value"])]]);
+    }
+  }
+
+  it("substitutes a promise sent as a Map value", async () => {
+    await using harness = new TestHarness(new MapTarget());
+    let stub = harness.stub;
+    using promise = stub.square(3);
+
+    let result = await stub.inspect(new Map<unknown, unknown>([
+      ["alpha", 1], ["beta", promise], ["omega", 3],
+    ]));
+
+    expect(result.isMap).toBe(true);
+    expect(result.entries).toStrictEqual([["alpha", 1], ["beta", 9], ["omega", 3]]);
+    expect(result.strayProps).toStrictEqual([]);
+  });
+
+  it("substitutes a promise sent as a Map key, preserving insertion order", async () => {
+    await using harness = new TestHarness(new MapTarget());
+    let stub = harness.stub;
+    using promise = stub.square(3);
+
+    let result = await stub.inspect(new Map<unknown, unknown>([
+      ["alpha", 1], [promise, 2], ["omega", 3],
+    ]));
+
+    // Rebuilding the Map must not move the resolved key to the end.
+    expect(result.entries).toStrictEqual([["alpha", 1], [9, 2], ["omega", 3]]);
+    expect(result.strayProps).toStrictEqual([]);
+  });
+
+  it("substitutes a promise key and a promise value in the same entry", async () => {
+    await using harness = new TestHarness(new MapTarget());
+    let stub = harness.stub;
+    using key = stub.square(3);
+    using value = stub.square(4);
+
+    // The key and the value each need their own slot, and either may land first.
+    let result = await stub.inspect(new Map<unknown, unknown>([[key, value]]));
+
+    expect(result.entries).toStrictEqual([[9, 16]]);
+    expect(result.strayProps).toStrictEqual([]);
+  });
+
+  it("substitutes multiple promises at their own positions", async () => {
+    await using harness = new TestHarness(new MapTarget());
+    let stub = harness.stub;
+    using first = stub.square(3);
+    using second = stub.square(4);
+    using third = stub.square(5);
+
+    let result = await stub.inspect(new Map<unknown, unknown>([
+      ["a", first], [second, "b"], ["c", 0], [third, third],
+    ]));
+
+    expect(result.entries).toStrictEqual([["a", 9], [16, "b"], ["c", 0], [25, 25]]);
+    expect(result.strayProps).toStrictEqual([]);
+  });
+
+  it("leaves no residue when a promise is nested inside a Map entry", async () => {
+    await using harness = new TestHarness(new MapTarget());
+    let stub = harness.stub;
+    using promise = stub.square(4);
+
+    // Here the promise's parent is the inner object, not the Map, so the Map needs no setter.
+    let result = await stub.inspect(new Map<unknown, unknown>([["k", {value: promise}]]));
+
+    expect(result.entries).toStrictEqual([["k", {value: 16}]]);
+    expect(result.strayProps).toStrictEqual([]);
+  });
+
+  it("collapses a key that resolves to an existing key", async () => {
+    await using harness = new TestHarness(new MapTarget());
+    let stub = harness.stub;
+    using promise = stub.square(3);
+
+    // Rebuilding the Map re-applies Map semantics: the later entry wins on value, but keeps the
+    // earlier entry's position.
+    let result = await stub.inspect(new Map<unknown, unknown>([
+      [9, "first"], [promise, "second"], ["tail", "third"],
+    ]));
+
+    expect(result.entries).toStrictEqual([[9, "second"], ["tail", "third"]]);
+    expect(result.strayProps).toStrictEqual([]);
+  });
+
+  it("substitutes Blobs in a Map returned to the caller", async () => {
+    await using harness = new TestHarness(new MapTarget());
+
+    let received = await harness.stub.makeBlobMap();
+
+    expect(received).toBeInstanceOf(Map);
+    expect(Object.getOwnPropertyNames(received)).toStrictEqual([]);
+    let [[key, value]] = [...received];
+    expect(await key.text()).toBe("key");
+    expect(await value.text()).toBe("value");
+  });
+
+  it("substitutes promises in a Map passed to a local stub", async () => {
+    using stub = new RpcStub(new MapTarget());
+    using key = stub.square(3);
+    using value = stub.square(4);
+    let source = new Map<unknown, unknown>([["alpha", value], [key, "omega"]]);
+
+    let result = await stub.inspect(source);
+
+    expect(result.entries).toStrictEqual([["alpha", 16], [9, "omega"]]);
+    expect(result.strayProps).toStrictEqual([]);
+
+    // deepCopy() must fix up its copy, not the caller's Map.
+    expect([...source]).toStrictEqual([["alpha", value], [key, "omega"]]);
+    expect(Object.getOwnPropertyNames(source)).toStrictEqual([]);
   });
 });
 

--- a/protocol.md
+++ b/protocol.md
@@ -191,6 +191,10 @@ bound parsing cost.
 
 A JavaScript `Date` value. The number represents milliseconds since the Unix epoch.
 
+`["map", entries]`
+
+A JavaScript `Map` value. `entries` is an array of `[key, value]` pairs, in insertion order.
+
 `["error", type, message, stack?, props?]`
 
 A JavaScript `Error` value. `type` is the name of the specific well-known `Error` subclass, e.g. "TypeError". `message` is a string containing the error message. `stack` may optionally contain the stack trace, though by default stacks will be redacted for security reasons.

--- a/src/core.ts
+++ b/src/core.ts
@@ -37,7 +37,7 @@ export let RpcTarget = workersModule ? workersModule.RpcTarget : class {};
 
 export type PropertyPath = (string | number)[];
 
-type TypeForRpc = "unsupported" | "primitive" | "object" | "function" | "array" | "date" |
+type TypeForRpc = "unsupported" | "primitive" | "object" | "function" | "array" | "date" | "map" |
     "bigint" | "bytes" | "blob" | "stub" | "rpc-promise" | "rpc-target" | "rpc-thenable" |
     "error" | "undefined" | "writable" | "readable" | "headers" | "request" | "response";
 
@@ -92,6 +92,9 @@ export function typeForRpc(value: unknown): TypeForRpc {
 
     case Date.prototype:
       return "date";
+
+    case Map.prototype:
+      return "map";
 
     case Uint8Array.prototype:
     case BUFFER_PROTOTYPE:
@@ -626,6 +629,47 @@ export function unwrapStubAndPath(stub: RpcStub): {hook: StubHook, pathIfPromise
   return stub[RAW_STUB];
 }
 
+// The property names used to address the key and the value of the `Map` entry at `index`.
+//
+// Delivery writes `parent[property] = resolved`, so every slot in the map needs its own name;
+// sharing one would make two writes target the same slot, losing all but the last.
+export function mapPromiseSlotProperties(index: number): {key: string, value: string} {
+  return {key: `${index}:key`, value: `${index}:value`};
+}
+
+// RpcPromise keys and values are set using property access on the parent.
+//
+// To make this work for `Map`, this function defines one-time-use setters that write the
+// resolution back into `entries` and rebuild the map from it. `entries` -- not the map -- is the
+// source of truth, so a key and its value can resolve in either order, and a key that resolves to
+// a duplicate collapses under normal `Map` semantics.
+//
+// `entries[index]` must be the entry that was inserted into `map` at position `index`.
+export function defineMapPromiseSlots(
+    map: Map<unknown, unknown>, entries: [unknown, unknown][], index: number) {
+  let entry = entries[index]!;
+  if (!(entry[0] instanceof RpcPromise) && !(entry[1] instanceof RpcPromise)) return;
+
+  let properties = mapPromiseSlotProperties(index);
+
+  let defineSlot = (property: string, slot: 0 | 1) => {
+    Object.defineProperty(map, property, {
+      configurable: true, enumerable: false,
+      set(resolved: unknown) {
+        delete (map as any)[property];
+        entries[index]![slot] = resolved;
+        map.clear();
+        for (let [key, value] of entries) {
+          map.set(key, value);
+        }
+      }
+    });
+  };
+
+  if (entry[0] instanceof RpcPromise) defineSlot(properties.key, 0);
+  if (entry[1] instanceof RpcPromise) defineSlot(properties.value, 1);
+}
+
 // Given a promise stub (still wrapped in a Proxy), pull the remote promise and deliver the
 // payload. This is a helper used to implement the then/catch/finally methods of RpcPromise.
 async function pullPromise(promise: RpcPromise): Promise<unknown> {
@@ -977,6 +1021,24 @@ export class RpcPayload {
         let result = new Array(len);
         for (let i = 0; i < len; i++) {
           result[i] = this.deepCopy(array[i], array, i, result, dupStubs, owner);
+        }
+        return result;
+      }
+
+      case "map": {
+        // We have to construct the new map first, then fill it in, so we can pass it as the
+        // parent.
+        let map = <Map<unknown, unknown>>value;
+        let result = new Map();
+        let entries: [unknown, unknown][] = [];
+        for (let [key, val] of map) {
+          let index = entries.length;
+          let properties = mapPromiseSlotProperties(index);
+          let keyCopy = this.deepCopy(key, map, properties.key, result, dupStubs, owner);
+          let valCopy = this.deepCopy(val, map, properties.value, result, dupStubs, owner);
+          entries.push([keyCopy, valCopy]);
+          defineMapPromiseSlots(result, entries, index);
+          result.set(keyCopy, valCopy);
         }
         return result;
       }
@@ -1357,6 +1419,15 @@ export class RpcPayload {
         return;
       }
 
+      case "map": {
+        let map = <Map<unknown, unknown>>value;
+        for (let [key, val] of map) {
+          this.disposeImpl(key, map);
+          this.disposeImpl(val, map);
+        }
+        return;
+      }
+
       case "object": {
         let object = <Record<string, unknown>>value;
         for (let i in object) {
@@ -1503,6 +1574,15 @@ export class RpcPayload {
         return;
       }
 
+      case "map": {
+        let map = <Map<unknown, unknown>>value;
+        for (let [key, val] of map) {
+          this.ignoreUnhandledRejectionsImpl(key);
+          this.ignoreUnhandledRejectionsImpl(val);
+        }
+        return;
+      }
+
       case "object": {
         let object = <Record<string, unknown>>value;
         for (let i in object) {
@@ -1641,6 +1721,7 @@ function followPath(value: unknown, parent: object | undefined,
       case "bytes":
       case "blob":
       case "date":
+      case "map":
       case "error":
       case "headers":
       case "request":

--- a/src/serialize.ts
+++ b/src/serialize.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT license found in the LICENSE.txt file or at:
 //     https://opensource.org/license/mit
 
-import { StubHook, RpcPayload, typeForRpc, RpcStub, RpcPromise, LocatedPromise, RpcTarget, unwrapStubAndPath, streamImpl, PromiseStubHook, PayloadStubHook } from "./core.js";
+import { StubHook, RpcPayload, typeForRpc, RpcStub, RpcPromise, LocatedPromise, RpcTarget, unwrapStubAndPath, streamImpl, PromiseStubHook, PayloadStubHook, defineMapPromiseSlots, mapPromiseSlotProperties } from "./core.js";
 
 export type ImportId = number;
 export type ExportId = number;
@@ -317,6 +317,18 @@ export class Devaluator {
         }
         // Wrap literal arrays in an outer one-element array, to "escape" them.
         return [result];
+      }
+
+      case "map": {
+        let map = <Map<unknown, unknown>>value;
+        let entries: unknown[] = [];
+        for (let [key, val] of map) {
+          entries.push([
+            this.devaluateImpl(key, map, depth + 1),
+            this.devaluateImpl(val, map, depth + 1),
+          ]);
+        }
+        return ["map", entries];
       }
 
       case "bigint":
@@ -839,6 +851,25 @@ export class Evaluator {
           }
           if (typeof value[1] == "number") {
             return new Date(value[1]);
+          }
+          break;
+        case "map":
+          if (value.length === 2 && value[1] instanceof Array) {
+            let map = new Map();
+            let entries: [unknown, unknown][] = [];
+            for (let entry of value[1]) {
+              if (!(entry instanceof Array) || entry.length !== 2) {
+                throw new TypeError("Map entries must be serialized as key/value pairs.");
+              }
+              let index = entries.length;
+              let properties = mapPromiseSlotProperties(index);
+              let key = this.evaluateImpl(entry[0], map, properties.key, depth + 1);
+              let val = this.evaluateImpl(entry[1], map, properties.value, depth + 1);
+              entries.push([key, val]);
+              defineMapPromiseSlots(map, entries, index);
+              map.set(key, val);
+            }
+            return map;
           }
           break;
         case "bytes": {


### PR DESCRIPTION
Adds serialization support for `Map`. Doesn't special case `.map()` like we do for arrays, uses the default. I think we don't need it is because `Map` itself doesn't have one, so it is not expected as much as it is on an Array. But I can see the use case of wanting to iterate over values of a `Map`.

Just like #229, we support lazy values for both keys and values of a map.

If we want to revisit `.map` over map elements, I think we should block `.map` support for `Map` in this.

Closes #230 