### PR TITLE
fix: prevent Bonk checkout credentials from persisting

### DIFF
--- a/.github/workflows/bonk-pr-review.yml
+++ b/.github/workflows/bonk-pr-review.yml
@@ -30,6 +30,7 @@ jobs:
         uses: actions/checkout@v7
         with:
           fetch-depth: 30
+          persist-credentials: false
 
       - name: Load review prompt
         id: prompt

--- a/.github/workflows/bonk.yml
+++ b/.github/workflows/bonk.yml
@@ -32,6 +32,7 @@ jobs:
         uses: actions/checkout@v7
         with:
           fetch-depth: 1
+          persist-credentials: false
 
       - name: Build prompt with triggering comment
         id: prompt


### PR DESCRIPTION
PR #217 scoped Bonk's App token to `NO_PUSH`, but `actions/checkout` also persisted the workflow `GITHUB_TOKEN` in Git's credential configuration. When Bonk pushed, Git used that persisted credential instead of the scoped App token, so the push still succeeded.

Set `persist-credentials: false` on every checkout in both Bonk workflows so Git can only use Bonk's scoped token.