### PR TITLE
Keep published runtime bundles ASCII-only

### DIFF
--- a/.changeset/ascii-only-dist.md
+++ b/.changeset/ascii-only-dist.md
@@ -2,4 +2,4 @@
 "capnweb": patch
 ---
 
-Keep the published runtime bundles ASCII-only. A doc comment introduced in 0.11.0 carried a U+2212 into every dist bundle, which breaks consumers that inline the bundle through Latin-1-only APIs like `btoa()`. The comment is fixed and the build now fails if any non-ASCII byte reaches a runtime bundle in `dist/`.
+Keep the published runtime bundles ASCII-only. A doc comment introduced by #209 (first published in 0.11.0) carried a U+2212 into every dist bundle, which breaks consumers that inline the bundle through Latin-1-only APIs like `btoa()`. The comment is fixed and the build now fails if any non-ASCII character reaches a runtime bundle in `dist/`.

--- a/.changeset/ascii-only-dist.md
+++ b/.changeset/ascii-only-dist.md
@@ -1,0 +1,5 @@
+---
+"capnweb": patch
+---
+
+Keep the published runtime bundles ASCII-only. A doc comment introduced in 0.11.0 carried a U+2212 into every dist bundle, which breaks consumers that inline the bundle through Latin-1-only APIs like `btoa()`. The comment is fixed and the build now fails if any non-ASCII byte reaches a runtime bundle in `dist/`.

--- a/.changeset/ascii-only-dist.md
+++ b/.changeset/ascii-only-dist.md
@@ -2,4 +2,4 @@
 "capnweb": patch
 ---
 
-Keep the published runtime bundles ASCII-only. A doc comment introduced by #209 (first published in 0.11.0) carried a U+2212 into every dist bundle, which breaks consumers that inline the bundle through Latin-1-only APIs like `btoa()`. The comment is fixed and the build now fails if any non-ASCII character reaches a runtime bundle in `dist/`.
+Keep the published runtime bundles ASCII-only. A doc comment introduced in 0.11.0 carried a U+2212 into every dist bundle, which breaks consumers that inline the bundle through Latin-1-only APIs like `btoa()`. The comment is fixed and the build now fails if any non-ASCII byte reaches a runtime bundle in `dist/`.

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "packages/*"
   ],
   "scripts": {
-    "build": "tsdown --config-loader native && npm run -w capnweb-validate build",
+    "build": "tsdown --config-loader native && node scripts/check-dist-ascii.mjs && npm run -w capnweb-validate build",
     "build:watch": "tsdown --config-loader native --watch",
     "test": "vitest run",
     "test:bun": "bun test __tests__/bun.test.ts",

--- a/scripts/check-dist-ascii.mjs
+++ b/scripts/check-dist-ascii.mjs
@@ -2,7 +2,7 @@
 // Licensed under the MIT license found in the LICENSE.txt file or at:
 //     https://opensource.org/license/mit
 
-// Fails the build if any runtime bundle in dist/ contains non-ASCII bytes.
+// Fails the build if any runtime bundle in dist/ contains non-ASCII characters.
 //
 // Consumers inline these bundles into `data:` URLs and similar wrappers, often
 // through Latin-1-only APIs like btoa(), where a single non-ASCII character
@@ -17,7 +17,7 @@ import { fileURLToPath } from "node:url";
 
 const distDir = fileURLToPath(new URL("../dist/", import.meta.url));
 
-const runtimeFiles = readdirSync(distDir).filter(
+const runtimeFiles = readdirSync(distDir, { recursive: true }).filter(
   (name) => /\.(js|cjs|mjs)$/.test(name) && !/\.d\.(ts|cts|mts)$/.test(name)
 );
 

--- a/scripts/check-dist-ascii.mjs
+++ b/scripts/check-dist-ascii.mjs
@@ -1,0 +1,42 @@
+// Copyright (c) 2025 Cloudflare, Inc.
+// Licensed under the MIT license found in the LICENSE.txt file or at:
+//     https://opensource.org/license/mit
+
+// Fails the build if any runtime bundle in dist/ contains non-ASCII bytes.
+//
+// Consumers inline these bundles into `data:` URLs and similar wrappers, often
+// through Latin-1-only APIs like btoa(), where a single non-ASCII character
+// either throws or silently corrupts. Which source comments survive bundling
+// is an implementation detail of the bundler, so the invariant is enforced on
+// the built output rather than on source. Runtime strings that genuinely need
+// non-ASCII characters can use \u escapes in source.
+
+import { readdirSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const distDir = fileURLToPath(new URL("../dist/", import.meta.url));
+
+const runtimeFiles = readdirSync(distDir).filter(
+  (name) => /\.(js|cjs|mjs)$/.test(name) && !/\.d\.(ts|cts|mts)$/.test(name)
+);
+
+let failures = 0;
+for (const name of runtimeFiles) {
+  const text = readFileSync(join(distDir, name), "utf8");
+  const match = /[^\x00-\x7F]/.exec(text);
+  if (match) {
+    const line = text.slice(0, match.index).split("\n").length;
+    const char = match[0].codePointAt(0).toString(16).toUpperCase().padStart(4, "0");
+    console.error(`dist/${name}:${line}: non-ASCII character U+${char}`);
+    failures++;
+  }
+}
+
+if (failures > 0) {
+  console.error(
+    `\n${failures} dist file(s) contain non-ASCII characters. Replace them in the ` +
+      `originating source (or use \\u escapes for runtime strings that need them).`
+  );
+  process.exit(1);
+}

--- a/src/websocket.ts
+++ b/src/websocket.ts
@@ -7,7 +7,7 @@
 import { RpcStub } from "./core.js";
 import { RpcSession, RpcSessionOptions } from "./rpc.js";
 
-/** Close-frame reason max UTF-8 bytes: 125 payload − 2-byte status (RFC 6455 §5.5). */
+/** Close-frame reason max UTF-8 bytes: 125 payload - 2-byte status (RFC 6455 section 5.5). */
 export const MAX_CLOSE_REASON_BYTES = 125 - 2;
 
 export function newWebSocketRpcSession(


### PR DESCRIPTION
0.11.0's dist bundles carry a U+2212 (typographic minus) from a `websocket.ts` doc comment (#209). Discovered in [Cloudflare OS capnweb bump](https://github.com/cloudflare/cloudflare-os/pull/175/changes#diff-f0b1fee712e9299c02886b19b53ccff8b2c4c14f70b1179b79447cff90ba7d78R17). Consumers that inline the bundle - e.g. into a `data:` URL via `btoa()`, which only accepts Latin-1 - throw on it, and anything in U+0080–U+00FF would corrupt silently instead.

This fixes the comment and adds a post-build check that fails if any non-ASCII byte reaches a runtime bundle in `dist/`. Runtime strings that legitimately need non-ASCII can use `\u` escapes in source.