### PR TITLE
capnweb-validate: ship typescript as a capped dependency

### DIFF
--- a/.changeset/validate-own-compiler.md
+++ b/.changeset/validate-own-compiler.md
@@ -1,0 +1,5 @@
+---
+"capnweb-validate": patch
+---
+
+Ship `typescript` as a dependency (`>=5.7.0 <7`) instead of an uncapped peer, so the build-time transform keeps a JS-based compiler API in TypeScript 7 (tsgo) workspaces.

--- a/package-lock.json
+++ b/package-lock.json
@@ -5955,7 +5955,6 @@
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
-      "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
@@ -7004,6 +7003,7 @@
       "version": "0.2.3",
       "license": "MIT",
       "dependencies": {
+        "typescript": ">=5.7.0 <7",
         "unplugin": "^3.0.0"
       },
       "bin": {
@@ -7012,12 +7012,10 @@
       "devDependencies": {
         "@typescript/vfs": "^1.6.4",
         "capnweb": "^0.11.0",
-        "tsdown": "^0.22.0",
-        "typescript": "^5.9.3"
+        "tsdown": "^0.22.0"
       },
       "peerDependencies": {
-        "capnweb": ">=0.7.0",
-        "typescript": ">=5.7.0"
+        "capnweb": ">=0.7.0"
       },
       "peerDependenciesMeta": {
         "capnweb": {

--- a/packages/capnweb-validate/package.json
+++ b/packages/capnweb-validate/package.json
@@ -75,14 +75,12 @@
     "test": "vitest run --root ../.. --project node packages/capnweb-validate/__tests__"
   },
   "peerDependencies": {
-    "capnweb": ">=0.7.0",
-    "typescript": ">=5.7.0"
+    "capnweb": ">=0.7.0"
   },
   "devDependencies": {
     "@typescript/vfs": "^1.6.4",
     "capnweb": "^0.11.0",
-    "tsdown": "^0.22.0",
-    "typescript": "^5.9.3"
+    "tsdown": "^0.22.0"
   },
   "publishConfig": {
     "access": "public"
@@ -92,6 +90,7 @@
     "url": "https://github.com/cloudflare/capnweb"
   },
   "dependencies": {
+    "typescript": ">=5.7.0 <7",
     "unplugin": "^3.0.0"
   },
   "peerDependenciesMeta": {


### PR DESCRIPTION
capnweb-validate's build-time transform needs the JS compiler API (`transpileModule`, `createProgram`, `ts.sys`), which TypeScript 7 (tsgo) no longer ships. The current peer is uncapped (`>=5.7.0`), so in a workspace whose `typescript` is 7.x the transform resolves a metadata-only package and dies at build time (`ts.sys` / `ts.findConfigFile` undefined). Working around it consumer-side takes a [`.pnpmfile.cjs` hook](https://github.com/cloudflare/cloudflare-os/pull/173/changes#diff-294bd10db07c43b10b4271610c9181fa32e67317ac9a373f495793f0ce8441f2R8), because pnpm resolves peers from the importer's context and neither `overrides` nor `packageExtensions` can move one.

This swaps the peer for a real dependency capped at `<7`: under a TS 7 workspace the transform gets its own JS-based compiler (transform compiler and check compiler are independent - checking with tsgo still works fine), and consumers on 5.7–6.x dedupe to their existing install. The 6.0.3 compiler is validated against the transform in a real consumer.