### PR TITLE
fix: dispose call args on all failure paths per new StubHook ownership contract

### DIFF
--- a/.changeset/promise-stubhook-disposal.md
+++ b/.changeset/promise-stubhook-disposal.md
@@ -1,0 +1,5 @@
+---
+"capnweb": patch
+---
+
+Fix `PromiseStubHook` to dispose copied call and stream arguments when the backing promise rejects, and to keep disposal ordered behind calls already queued on the promise.

--- a/.changeset/promise-stubhook-disposal.md
+++ b/.changeset/promise-stubhook-disposal.md
@@ -2,4 +2,4 @@
 "capnweb": patch
 ---
 
-Fix RPC argument and capture leaks on failure paths — rejected or broken destination hooks and local call errors now dispose the arguments they own — and keep `PromiseStubHook` disposal ordered behind already-queued calls.
+Establish and document the `StubHook` ownership contract: `call()`, `stream()`, and `map()` take ownership of their args/captures even when they throw synchronously, so callers must never dispose them after invoking. Fix implementations that violated the contract and leaked on failure paths: `RpcImportHook.call()/stream()` (including argument-serialization failures in `sendCall`/`sendStream`), `MapVariableHook`, the default `StubHook.stream()` (leaked the result hook when `pull()` threw), and the map-not-loaded placeholder. `PromiseStubHook` now disposes args only when its backing promise rejects — once resolved, the callee owns them — and its disposal remains ordered behind already-queued calls.

--- a/.changeset/promise-stubhook-disposal.md
+++ b/.changeset/promise-stubhook-disposal.md
@@ -2,4 +2,4 @@
 "capnweb": patch
 ---
 
-Fix RPC argument and capture leaks on failure paths: call arguments are now reliably disposed when a call is rejected, delivered to a broken or disposed stub, or fails to serialize. Internally, `StubHook.call()`/`stream()`/`map()` now document and follow a callee-takes-ownership contract, even on synchronous throw.
+Fix RPC argument and capture leaks on failure paths: call arguments are now reliably disposed when a call is rejected, delivered to a broken or disposed stub, or fails to serialize.

--- a/.changeset/promise-stubhook-disposal.md
+++ b/.changeset/promise-stubhook-disposal.md
@@ -2,4 +2,4 @@
 "capnweb": patch
 ---
 
-Establish and document the `StubHook` ownership contract: `call()`, `stream()`, and `map()` take ownership of their args/captures even when they throw synchronously, so callers must never dispose them after invoking. Fix implementations that violated the contract and leaked on failure paths: `RpcImportHook.call()/stream()` (including argument-serialization failures in `sendCall`/`sendStream`), `MapVariableHook`, the default `StubHook.stream()` (leaked the result hook when `pull()` threw), and the map-not-loaded placeholder. `PromiseStubHook` now disposes args only when its backing promise rejects — once resolved, the callee owns them — and its disposal remains ordered behind already-queued calls.
+Fix RPC argument and capture leaks on failure paths: call arguments are now reliably disposed when a call is rejected, delivered to a broken or disposed stub, or fails to serialize. Internally, `StubHook.call()`/`stream()`/`map()` now document and follow a callee-takes-ownership contract, even on synchronous throw.

--- a/.changeset/promise-stubhook-disposal.md
+++ b/.changeset/promise-stubhook-disposal.md
@@ -2,4 +2,4 @@
 "capnweb": patch
 ---
 
-Fix `PromiseStubHook` to dispose copied call and stream arguments when the backing promise rejects, and to keep disposal ordered behind calls already queued on the promise.
+Fix RPC argument and capture leaks on failure paths — rejected or broken destination hooks and local call errors now dispose the arguments they own — and keep `PromiseStubHook` disposal ordered behind already-queued calls.

--- a/__tests__/index.test.ts
+++ b/__tests__/index.test.ts
@@ -9,7 +9,7 @@ import { deserialize, serialize, RpcSession, type RpcSessionOptions, RpcTranspor
          newHttpBatchRpcSession} from "../src/index.js"
 import { swapByteOrder } from "../src/serialize.js"
 import { MAX_CLOSE_REASON_BYTES } from "../src/websocket.js"
-import { PromiseStubHook, RpcPayload, RpcStub as RawRpcStub, streamImpl,
+import { ErrorStubHook, PayloadStubHook, PromiseStubHook, RpcPayload, RpcStub as RawRpcStub, streamImpl,
          unwrapStubTakingOwnership } from "../src/core.js"
 import { Counter, TestTarget } from "./test-util.js";
 
@@ -2227,6 +2227,65 @@ describe("PromiseStubHook", () => {
 
     expect(disposed).toBe(false);
     expect(await result).toBe(3);
+    expect(disposed).toBe(true);
+  });
+
+  it("disposes copied call arguments when the destination hook is broken", async () => {
+    let disposed = false;
+    class Disposable extends RpcTarget {
+      [Symbol.dispose]() { disposed = true; }
+    }
+
+    let argument = new RpcStub(new Disposable());
+    let hook = new PromiseStubHook(Promise.resolve(new ErrorStubHook(new Error("broken"))));
+    let result = hook.call([], RpcPayload.fromAppParams([argument]));
+
+    await expect(result.pull()).rejects.toThrow("broken");
+    argument[Symbol.dispose]();
+    expect(disposed).toBe(true);
+  });
+
+  it("disposes copied stream arguments when the destination hook is broken", async () => {
+    let disposed = false;
+    class Disposable extends RpcTarget {
+      [Symbol.dispose]() { disposed = true; }
+    }
+
+    let argument = new RpcStub(new Disposable());
+    let hook = new PromiseStubHook(Promise.resolve(new ErrorStubHook(new Error("broken"))));
+    let result = hook.stream(["write"], RpcPayload.fromAppParams([argument]));
+
+    await expect(result.promise).rejects.toThrow("broken");
+    argument[Symbol.dispose]();
+    expect(disposed).toBe(true);
+  });
+
+  it("disposes copied call arguments when the local call path fails", async () => {
+    let disposed = false;
+    class Disposable extends RpcTarget {
+      [Symbol.dispose]() { disposed = true; }
+    }
+
+    let argument = new RpcStub(new Disposable());
+    let hook = new PromiseStubHook(
+        Promise.resolve(new PayloadStubHook(RpcPayload.fromAppReturn({}))));
+    let result = hook.call(["nope"], RpcPayload.fromAppParams([argument]));
+
+    await expect(result.pull()).rejects.toThrow("'nope' is not a function");
+    argument[Symbol.dispose]();
+    expect(disposed).toBe(true);
+    hook.dispose();
+  });
+
+  it("disposes map captures when the destination hook is broken", () => {
+    let disposed = false;
+    class Disposable extends RpcTarget {
+      [Symbol.dispose]() { disposed = true; }
+    }
+
+    let capture = unwrapStubTakingOwnership(<any>new RpcStub(new Disposable()));
+    let hook = new ErrorStubHook(new Error("broken"));
+    hook.map([], [capture], []);
     expect(disposed).toBe(true);
   });
 });

--- a/__tests__/index.test.ts
+++ b/__tests__/index.test.ts
@@ -2278,20 +2278,15 @@ describe("PromiseStubHook", () => {
   // A minimal contract-honoring callee: its call() takes ownership of `args` (disposing them)
   // and then throws synchronously. Used to pin the division of labor: once the backing promise
   // resolves, args ownership lies with the resolved callee, not with PromiseStubHook.
-  class SyncThrowingHook extends StubHook {
+  //
+  // Extends ErrorStubHook only to inherit harmless implementations of the methods these tests
+  // never invoke; note it does not override stream(), so the base StubHook.stream() is used.
+  class SyncThrowingHook extends ErrorStubHook {
+    constructor() { super(new Error("unused")); }
     call(path: PropertyPath, args: RpcPayload): StubHook {
       args.dispose();
       throw new Error("sync failure");
     }
-    map(path: PropertyPath, captures: StubHook[], instructions: unknown[]): StubHook {
-      throw new Error("not implemented");
-    }
-    get(path: PropertyPath): StubHook { throw new Error("not implemented"); }
-    dup(): StubHook { return this; }
-    pull(): RpcPayload | Promise<RpcPayload> { throw new Error("not implemented"); }
-    ignoreUnhandledRejections(): void {}
-    dispose(): void {}
-    onBroken(callback: (error: any) => void): void {}
   }
 
   it("leaves call args ownership with a resolved callee whose call() throws synchronously",

--- a/__tests__/index.test.ts
+++ b/__tests__/index.test.ts
@@ -9,8 +9,8 @@ import { deserialize, serialize, RpcSession, type RpcSessionOptions, RpcTranspor
          newHttpBatchRpcSession} from "../src/index.js"
 import { swapByteOrder } from "../src/serialize.js"
 import { MAX_CLOSE_REASON_BYTES } from "../src/websocket.js"
-import { ErrorStubHook, PayloadStubHook, PromiseStubHook, RpcPayload, RpcStub as RawRpcStub, streamImpl,
-         unwrapStubTakingOwnership } from "../src/core.js"
+import { ErrorStubHook, PayloadStubHook, PromiseStubHook, RpcPayload, RpcStub as RawRpcStub,
+         StubHook, streamImpl, unwrapStubTakingOwnership, type PropertyPath } from "../src/core.js"
 import { Counter, TestTarget } from "./test-util.js";
 
 type CustomEncodingLevel = RpcTransportWithCustomEncoding["encodingLevel"];
@@ -2180,35 +2180,37 @@ describe("onRpcBroken", () => {
 
 // =======================================================================================
 
+// Creates an RpcTarget that records whether its disposer has run, for verifying that a payload
+// containing (a copy of) it was properly disposed.
+function disposalSpy() {
+  let disposed = false;
+  class Disposable extends RpcTarget {
+    [Symbol.dispose]() { disposed = true; }
+  }
+  return { target: new Disposable(), wasDisposed: () => disposed };
+}
+
 describe("PromiseStubHook", () => {
   it("disposes copied call arguments when the backing promise rejects", async () => {
-    let disposed = false;
-    class Disposable extends RpcTarget {
-      [Symbol.dispose]() { disposed = true; }
-    }
-
-    let argument = new RpcStub(new Disposable());
+    let spy = disposalSpy();
+    let argument = new RpcStub(spy.target);
     let hook = new PromiseStubHook(Promise.reject(new Error("nope")));
     let result = hook.call([], RpcPayload.fromAppParams([argument]));
 
     await expect(result.pull()).rejects.toThrow("nope");
     argument[Symbol.dispose]();
-    expect(disposed).toBe(true);
+    expect(spy.wasDisposed()).toBe(true);
   });
 
   it("disposes copied stream arguments when the backing promise rejects", async () => {
-    let disposed = false;
-    class Disposable extends RpcTarget {
-      [Symbol.dispose]() { disposed = true; }
-    }
-
-    let argument = new RpcStub(new Disposable());
+    let spy = disposalSpy();
+    let argument = new RpcStub(spy.target);
     let hook = new PromiseStubHook(Promise.reject(new Error("nope")));
     let result = hook.stream(["write"], RpcPayload.fromAppParams([argument]));
 
     await expect(result.promise).rejects.toThrow("nope");
     argument[Symbol.dispose]();
-    expect(disposed).toBe(true);
+    expect(spy.wasDisposed()).toBe(true);
   });
 
   it("delivers a call initiated before disposal", async () => {
@@ -2231,62 +2233,151 @@ describe("PromiseStubHook", () => {
   });
 
   it("disposes copied call arguments when the destination hook is broken", async () => {
-    let disposed = false;
-    class Disposable extends RpcTarget {
-      [Symbol.dispose]() { disposed = true; }
-    }
-
-    let argument = new RpcStub(new Disposable());
+    let spy = disposalSpy();
+    let argument = new RpcStub(spy.target);
     let hook = new PromiseStubHook(Promise.resolve(new ErrorStubHook(new Error("broken"))));
     let result = hook.call([], RpcPayload.fromAppParams([argument]));
 
     await expect(result.pull()).rejects.toThrow("broken");
     argument[Symbol.dispose]();
-    expect(disposed).toBe(true);
+    expect(spy.wasDisposed()).toBe(true);
   });
 
   it("disposes copied stream arguments when the destination hook is broken", async () => {
-    let disposed = false;
-    class Disposable extends RpcTarget {
-      [Symbol.dispose]() { disposed = true; }
-    }
-
-    let argument = new RpcStub(new Disposable());
+    let spy = disposalSpy();
+    let argument = new RpcStub(spy.target);
     let hook = new PromiseStubHook(Promise.resolve(new ErrorStubHook(new Error("broken"))));
     let result = hook.stream(["write"], RpcPayload.fromAppParams([argument]));
 
     await expect(result.promise).rejects.toThrow("broken");
     argument[Symbol.dispose]();
-    expect(disposed).toBe(true);
+    expect(spy.wasDisposed()).toBe(true);
   });
 
   it("disposes copied call arguments when the local call path fails", async () => {
-    let disposed = false;
-    class Disposable extends RpcTarget {
-      [Symbol.dispose]() { disposed = true; }
-    }
-
-    let argument = new RpcStub(new Disposable());
+    let spy = disposalSpy();
+    let argument = new RpcStub(spy.target);
     let hook = new PromiseStubHook(
         Promise.resolve(new PayloadStubHook(RpcPayload.fromAppReturn({}))));
     let result = hook.call(["nope"], RpcPayload.fromAppParams([argument]));
 
     await expect(result.pull()).rejects.toThrow("'nope' is not a function");
     argument[Symbol.dispose]();
-    expect(disposed).toBe(true);
+    expect(spy.wasDisposed()).toBe(true);
     hook.dispose();
   });
 
   it("disposes map captures when the destination hook is broken", () => {
-    let disposed = false;
-    class Disposable extends RpcTarget {
-      [Symbol.dispose]() { disposed = true; }
-    }
-
-    let capture = unwrapStubTakingOwnership(<any>new RpcStub(new Disposable()));
+    let spy = disposalSpy();
+    let capture = unwrapStubTakingOwnership(<any>new RpcStub(spy.target));
     let hook = new ErrorStubHook(new Error("broken"));
     hook.map([], [capture], []);
-    expect(disposed).toBe(true);
+    expect(spy.wasDisposed()).toBe(true);
+  });
+
+  // A minimal contract-honoring callee: its call() takes ownership of `args` (disposing them)
+  // and then throws synchronously. Used to pin the division of labor: once the backing promise
+  // resolves, args ownership lies with the resolved callee, not with PromiseStubHook.
+  class SyncThrowingHook extends StubHook {
+    call(path: PropertyPath, args: RpcPayload): StubHook {
+      args.dispose();
+      throw new Error("sync failure");
+    }
+    map(path: PropertyPath, captures: StubHook[], instructions: unknown[]): StubHook {
+      throw new Error("not implemented");
+    }
+    get(path: PropertyPath): StubHook { throw new Error("not implemented"); }
+    dup(): StubHook { return this; }
+    pull(): RpcPayload | Promise<RpcPayload> { throw new Error("not implemented"); }
+    ignoreUnhandledRejections(): void {}
+    dispose(): void {}
+    onBroken(callback: (error: any) => void): void {}
+  }
+
+  it("leaves call args ownership with a resolved callee whose call() throws synchronously",
+      async () => {
+    let spy = disposalSpy();
+    let argument = new RpcStub(spy.target);
+    let hook = new PromiseStubHook(Promise.resolve(new SyncThrowingHook()));
+    let result = hook.call([], RpcPayload.fromAppParams([argument]));
+
+    await expect(result.pull()).rejects.toThrow("sync failure");
+    argument[Symbol.dispose]();
+    expect(spy.wasDisposed()).toBe(true);
+  });
+
+  it("leaves stream args ownership with a resolved callee whose call() throws synchronously",
+      async () => {
+    let spy = disposalSpy();
+    let argument = new RpcStub(spy.target);
+    let hook = new PromiseStubHook(Promise.resolve(new SyncThrowingHook()));
+    // SyncThrowingHook inherits the default stream(), which delegates to call().
+    let result = hook.stream(["write"], RpcPayload.fromAppParams([argument]));
+
+    await expect(result.promise).rejects.toThrow("sync failure");
+    argument[Symbol.dispose]();
+    expect(spy.wasDisposed()).toBe(true);
+  });
+
+  it("default stream() disposes the result hook when pull() throws synchronously", () => {
+    let resultHookDisposed = false;
+
+    class ThrowingPullHook extends SyncThrowingHook {
+      pull(): RpcPayload | Promise<RpcPayload> { throw new Error("pull failed"); }
+      dispose(): void { resultHookDisposed = true; }
+    }
+
+    class LocalCallHook extends SyncThrowingHook {
+      // Inherits the base StubHook.stream(), which delegates to call() + pull().
+      call(path: PropertyPath, args: RpcPayload): StubHook {
+        args.dispose();
+        return new ThrowingPullHook();
+      }
+    }
+
+    expect(() => new LocalCallHook().stream(["write"], RpcPayload.fromAppParams([])))
+        .toThrow("pull failed");
+    expect(resultHookDisposed).toBe(true);
+  });
+});
+
+describe("RpcImportHook argument disposal", () => {
+  it("call() disposes owned args when argument serialization fails", async () => {
+    await using harness = new TestHarness(new TestTarget());
+
+    let spy = disposalSpy();
+    let argument = new RpcStub(spy.target);
+
+    let hook = unwrapStubTakingOwnership(<any>harness.stub.dup());
+
+    // The stub is serialized (and exported) before the Symbol makes devaluation fail, so this
+    // exercises both the Devaluator's export rollback and the disposal of the owned payload.
+    let payload = RpcPayload.fromAppParams([argument, Symbol("unserializable")]);
+    payload.ensureDeepCopied();
+
+    expect(() => hook.call(["square"], payload)).toThrow("Cannot serialize value");
+
+    hook.dispose();
+    argument[Symbol.dispose]();
+    expect(spy.wasDisposed()).toBe(true);
+  });
+
+  it("stream() disposes owned args when argument serialization fails", async () => {
+    await using harness = new TestHarness(new TestTarget());
+
+    let spy = disposalSpy();
+    let argument = new RpcStub(spy.target);
+
+    let hook = unwrapStubTakingOwnership(<any>harness.stub.dup());
+
+    let payload = RpcPayload.fromAppParams([argument, Symbol("unserializable")]);
+    payload.ensureDeepCopied();
+
+    expect(() => hook.stream(["square"], payload)).toThrow("Cannot serialize value");
+
+    hook.dispose();
+    argument[Symbol.dispose]();
+    expect(spy.wasDisposed()).toBe(true);
   });
 });
 

--- a/__tests__/index.test.ts
+++ b/__tests__/index.test.ts
@@ -9,7 +9,8 @@ import { deserialize, serialize, RpcSession, type RpcSessionOptions, RpcTranspor
          newHttpBatchRpcSession} from "../src/index.js"
 import { swapByteOrder } from "../src/serialize.js"
 import { MAX_CLOSE_REASON_BYTES } from "../src/websocket.js"
-import { PromiseStubHook, RpcPayload, streamImpl } from "../src/core.js"
+import { PromiseStubHook, RpcPayload, RpcStub as RawRpcStub, streamImpl,
+         unwrapStubTakingOwnership } from "../src/core.js"
 import { Counter, TestTarget } from "./test-util.js";
 
 type CustomEncodingLevel = RpcTransportWithCustomEncoding["encodingLevel"];
@@ -2174,6 +2175,59 @@ describe("onRpcBroken", () => {
       {which: "counter1", error: new Error("test disconnect")},
       {which: "hangingCall", error: new Error("test disconnect")},
     ]);
+  });
+});
+
+// =======================================================================================
+
+describe("PromiseStubHook", () => {
+  it("disposes copied call arguments when the backing promise rejects", async () => {
+    let disposed = false;
+    class Disposable extends RpcTarget {
+      [Symbol.dispose]() { disposed = true; }
+    }
+
+    let argument = new RpcStub(new Disposable());
+    let hook = new PromiseStubHook(Promise.reject(new Error("nope")));
+    let result = hook.call([], RpcPayload.fromAppParams([argument]));
+
+    await expect(result.pull()).rejects.toThrow("nope");
+    argument[Symbol.dispose]();
+    expect(disposed).toBe(true);
+  });
+
+  it("disposes copied stream arguments when the backing promise rejects", async () => {
+    let disposed = false;
+    class Disposable extends RpcTarget {
+      [Symbol.dispose]() { disposed = true; }
+    }
+
+    let argument = new RpcStub(new Disposable());
+    let hook = new PromiseStubHook(Promise.reject(new Error("nope")));
+    let result = hook.stream(["write"], RpcPayload.fromAppParams([argument]));
+
+    await expect(result.promise).rejects.toThrow("nope");
+    argument[Symbol.dispose]();
+    expect(disposed).toBe(true);
+  });
+
+  it("delivers a call initiated before disposal", async () => {
+    let disposed = false;
+    class DisposableCounter extends Counter {
+      [Symbol.dispose]() { disposed = true; }
+    }
+
+    let inner = new RpcStub(new DisposableCounter(1));
+    let hook = new PromiseStubHook(Promise.resolve(unwrapStubTakingOwnership(<any>inner)));
+    await pumpMicrotasks();
+
+    let stub: RpcStub<Counter> = <any>new RawRpcStub(hook);
+    let result = stub.increment(2);
+    stub[Symbol.dispose]();
+
+    expect(disposed).toBe(false);
+    expect(await result).toBe(3);
+    expect(disposed).toBe(true);
   });
 });
 

--- a/src/core.ts
+++ b/src/core.ts
@@ -1992,7 +1992,12 @@ export class PromiseStubHook extends StubHook {
     // can't serialize them yet, we have to deep-copy them now.
     args.ensureDeepCopied();
 
-    return new PromiseStubHook(this.promise.then(hook => hook.call(path, args)));
+    return new PromiseStubHook(this.promise.then(
+        hook => hook.call(path, args),
+        err => {
+          args.dispose();
+          throw err;
+        }));
   }
 
   stream(path: PropertyPath, args: RpcPayload): {promise: Promise<void>, size?: number} {
@@ -2000,10 +2005,15 @@ export class PromiseStubHook extends StubHook {
     // No size is returned because we can't know yet; this means the caller will await the promise,
     // which is the safe default (serialized writes).
     args.ensureDeepCopied();
-    let promise = this.promise.then(hook => {
-      let result = hook.stream(path, args);
-      return result.promise;
-    });
+    let promise = this.promise.then(
+        hook => {
+          let result = hook.stream(path, args);
+          return result.promise;
+        },
+        err => {
+          args.dispose();
+          throw err;
+        });
     return { promise };
   }
 
@@ -2056,15 +2066,11 @@ export class PromiseStubHook extends StubHook {
   }
 
   dispose(): void {
-    if (this.resolution) {
-      this.resolution.dispose();
-    } else {
-      this.promise.then(hook => {
-        hook.dispose();
-      }, err => {
-        // nothing to dispose
-      });
-    }
+    // Keep disposal behind calls already queued on this promise. Unlike pull(), dup(), and
+    // onBroken(), dispose() must not take a fast path through `this.resolution` even once it is
+    // available: it is the one destructive operation here, and a call chained on the promise just
+    // before disposal would otherwise be delivered after its target was disposed.
+    this.promise.then(hook => hook.dispose(), () => {});
   }
 
   onBroken(callback: (error: any) => void): void {

--- a/src/core.ts
+++ b/src/core.ts
@@ -2086,10 +2086,10 @@ export class PromiseStubHook extends StubHook {
   }
 
   dispose(): void {
-    // Keep disposal behind calls already queued on this promise. Unlike pull(), dup(), and
-    // onBroken(), dispose() must not take a fast path through `this.resolution` even once it is
-    // available: it is the one destructive operation here, and a call chained on the promise just
-    // before disposal would otherwise be delivered after its target was disposed.
+    // We can't take the fast path here when this.resolution is available because if the resolution
+    // was just recently delivered, promise waiters may not have had a chance to consume it yet,
+    // and disposing it would preempt them. If we always wait on `this.promise` then we'll
+    // run after anything that was queued before us.
     this.promise.then(hook => hook.dispose(), () => {});
   }
 

--- a/src/core.ts
+++ b/src/core.ts
@@ -173,10 +173,22 @@ function mapNotLoaded(): never {
 
 // map() is implemented in `map.ts`. We can't import it here because it would create an import
 // cycle, so instead we define two hook functions that map.ts will overwrite when it is imported.
-export let mapImpl: MapImpl = { applyMap: mapNotLoaded, sendMap: mapNotLoaded };
+export let mapImpl: MapImpl = {
+  applyMap(input, parent, owner, captures, instructions) {
+    // applyMap() takes ownership of `captures` even when it throws.
+    for (let cap of captures) {
+      cap.dispose();
+    }
+    mapNotLoaded();
+  },
+  sendMap: mapNotLoaded
+};
 
 type MapImpl = {
   // Applies a map function to an input value (usually an array).
+  //
+  // Takes ownership of `captures`, including when it throws synchronously, per the contract of
+  // StubHook.map().
   applyMap(input: unknown, parent: object | undefined, owner: RpcPayload | null,
            captures: StubHook[], instructions: unknown[])
           : StubHook;
@@ -221,6 +233,12 @@ export type StreamImpl = {
 export abstract class StubHook {
   // Call a function at the given property path with the given arguments. Returns a hook for the
   // promise for the result.
+  //
+  // call() takes ownership of `args`, including when it throws synchronously. Every
+  // implementation must arrange for `args` to be disposed on all failure paths as well as on
+  // success. Correspondingly, callers must never dispose `args` after invoking call(), even if
+  // it threw. Note that RpcPayload.dispose() is idempotent, so an implementation that delegates
+  // to another hook's call() may still dispose `args` defensively in its own catch block.
   abstract call(path: PropertyPath, args: RpcPayload): StubHook;
 
   // Like call(), but designed for streaming calls (e.g. WritableStream writes). Returns:
@@ -228,11 +246,19 @@ export abstract class StubHook {
   // - size: If the call was remote, the byte size of the serialized message. For local calls,
   //   undefined is returned, indicating the caller should await the promise to serialize writes
   //   (no overlapping).
+  //
+  // stream() takes ownership of `args` under the same rules as call().
   stream(path: PropertyPath, args: RpcPayload): {promise: Promise<void>, size?: number} {
     // Default implementation: delegate to call() + pull(). No size is returned, so the caller
     // knows this is a local call and should await the promise directly.
     let hook = this.call(path, args);
-    let pulled = hook.pull();
+    let pulled: RpcPayload | Promise<RpcPayload>;
+    try {
+      pulled = hook.pull();
+    } catch (err) {
+      hook.dispose();
+      throw err;
+    }
     let promise: Promise<void>;
     if (pulled instanceof Promise) {
       promise = pulled.then(p => { p.dispose(); });
@@ -246,7 +272,10 @@ export abstract class StubHook {
   // Apply a map operation.
   //
   // `captures` is a list of external stubs which are used as part of the mapper function.
-  // NOTE: The callee takes ownership of `captures`.
+  // NOTE: The callee takes ownership of `captures`, including when map() throws synchronously;
+  // callers must not dispose them afterwards. StubHook.dispose() is safe to call multiple times,
+  // so an implementation that delegates to another hook's map() may still dispose the captures
+  // defensively.
   //
   // `instructions` is a JSON-serializable value describing the mapper function as a series of
   // steps. Each step is an expression to evaluate, in the usual RPC expression format. The last
@@ -318,8 +347,8 @@ export abstract class StubHook {
 export class ErrorStubHook extends StubHook {
   constructor(private error: any) { super(); }
 
-  // call() and map() take ownership of `args` / `captures`; there is no callee here to consume
-  // them, so dispose them before reporting the error.
+  // Per the StubHook contract, call() and map() take ownership of `args` / `captures` even on
+  // failure. No callee sits behind this hook to consume them, so dispose them immediately.
   call(path: PropertyPath, args: RpcPayload): StubHook { args.dispose(); return this; }
   map(path: PropertyPath, captures: StubHook[], instructions: unknown[]): StubHook {
     for (let cap of captures) {
@@ -1707,27 +1736,33 @@ abstract class ValueStubHook extends StubHook {
   protected abstract getValue(): {value: unknown, owner: RpcPayload | null};
 
   call(path: PropertyPath, args: RpcPayload): StubHook {
+    let followResult: FollowPathResult;
     try {
       let {value, owner} = this.getValue();
-      let followResult = followPath(value, undefined, path, owner);
-
-      if (followResult.hook) {
-        return followResult.hook.call(followResult.remainingPath, args);
-      }
-
-      // It's a local function.
-      if (typeof followResult.value != "function") {
-        throw new TypeError(`'${path.join('.')}' is not a function.`);
-      }
-      let promise = args.deliverCall(followResult.value, followResult.parent);
-      return new PromiseStubHook(promise.then(payload => {
-        return new PayloadStubHook(payload);
-      }));
+      followResult = followPath(value, undefined, path, owner);
     } catch (err) {
       // We took ownership of `args`, and there is no callee left to consume them.
       args.dispose();
       return new ErrorStubHook(err);
     }
+
+    if (followResult.hook) {
+      // The delegate's call() takes ownership of `args`, per the StubHook contract.
+      return followResult.hook.call(followResult.remainingPath, args);
+    }
+
+    // It's a local function.
+    if (typeof followResult.value != "function") {
+      args.dispose();
+      return new ErrorStubHook(new TypeError(`'${path.join('.')}' is not a function.`));
+    }
+
+    // deliverCall() is async and disposes `args` itself when the call completes, so it never
+    // needs a guard here.
+    let promise = args.deliverCall(followResult.value, followResult.parent);
+    return new PromiseStubHook(promise.then(payload => {
+      return new PayloadStubHook(payload);
+    }));
   }
 
   map(path: PropertyPath, captures: StubHook[], instructions: unknown[]): StubHook {
@@ -1751,6 +1786,9 @@ abstract class ValueStubHook extends StubHook {
       return mapImpl.applyMap(
           followResult.value, followResult.parent, followResult.owner, captures, instructions);
     } catch (err) {
+      // The inner catch above covers getValue()/followPath(). Past that point, the delegate's
+      // map() and applyMap() take ownership of the captures per the contract, so no disposal is
+      // needed here.
       return new ErrorStubHook(err);
     }
   }
@@ -2002,15 +2040,9 @@ export class PromiseStubHook extends StubHook {
     args.ensureDeepCopied();
 
     return new PromiseStubHook(this.promise.then(
-        hook => {
-          try {
-            return hook.call(path, args);
-          } catch (err) {
-            args.dispose();
-            throw err;
-          }
-        },
+        hook => hook.call(path, args),
         err => {
+          // The backing promise rejected, so no callee ever existed to take ownership of `args`.
           args.dispose();
           throw err;
         }));
@@ -2022,15 +2054,9 @@ export class PromiseStubHook extends StubHook {
     // which is the safe default (serialized writes).
     args.ensureDeepCopied();
     let promise = this.promise.then(
-        hook => {
-          try {
-            return hook.stream(path, args).promise;
-          } catch (err) {
-            args.dispose();
-            throw err;
-          }
-        },
+        hook => hook.stream(path, args).promise,
         err => {
+          // The backing promise rejected, so no callee ever existed to take ownership of `args`.
           args.dispose();
           throw err;
         });
@@ -2041,6 +2067,8 @@ export class PromiseStubHook extends StubHook {
     return new PromiseStubHook(this.promise.then(
         hook => hook.map(path, captures, instructions),
         err => {
+          // The backing promise rejected, so no callee ever existed to take ownership of the
+          // captures.
           for (let cap of captures) {
             cap.dispose();
           }

--- a/src/core.ts
+++ b/src/core.ts
@@ -1767,17 +1767,8 @@ abstract class ValueStubHook extends StubHook {
 
   map(path: PropertyPath, captures: StubHook[], instructions: unknown[]): StubHook {
     try {
-      let followResult: FollowPathResult;
-      try {
-        let {value, owner} = this.getValue();
-        followResult = followPath(value, undefined, path, owner);;
-      } catch (err) {
-        // Oops, we need to dispose the captures of which we took ownership.
-        for (let cap of captures) {
-          cap.dispose();
-        }
-        throw err;
-      }
+      let {value, owner} = this.getValue();
+      let followResult = followPath(value, undefined, path, owner);
 
       if (followResult.hook) {
         return followResult.hook.map(followResult.remainingPath, captures, instructions);
@@ -1786,9 +1777,12 @@ abstract class ValueStubHook extends StubHook {
       return mapImpl.applyMap(
           followResult.value, followResult.parent, followResult.owner, captures, instructions);
     } catch (err) {
-      // The inner catch above covers getValue()/followPath(). Past that point, the delegate's
-      // map() and applyMap() take ownership of the captures per the contract, so no disposal is
-      // needed here.
+      // We took ownership of the captures. If the delegate's map() or applyMap() threw, they
+      // already disposed the captures per the contract, but dispose() is idempotent so disposing
+      // again is harmless.
+      for (let cap of captures) {
+        cap.dispose();
+      }
       return new ErrorStubHook(err);
     }
   }

--- a/src/core.ts
+++ b/src/core.ts
@@ -173,16 +173,7 @@ function mapNotLoaded(): never {
 
 // map() is implemented in `map.ts`. We can't import it here because it would create an import
 // cycle, so instead we define two hook functions that map.ts will overwrite when it is imported.
-export let mapImpl: MapImpl = {
-  applyMap(input, parent, owner, captures, instructions) {
-    // applyMap() takes ownership of `captures` even when it throws.
-    for (let cap of captures) {
-      cap.dispose();
-    }
-    mapNotLoaded();
-  },
-  sendMap: mapNotLoaded
-};
+export let mapImpl: MapImpl = { applyMap: mapNotLoaded, sendMap: mapNotLoaded };
 
 type MapImpl = {
   // Applies a map function to an input value (usually an array).
@@ -1767,8 +1758,17 @@ abstract class ValueStubHook extends StubHook {
 
   map(path: PropertyPath, captures: StubHook[], instructions: unknown[]): StubHook {
     try {
-      let {value, owner} = this.getValue();
-      let followResult = followPath(value, undefined, path, owner);
+      let followResult: FollowPathResult;
+      try {
+        let {value, owner} = this.getValue();
+        followResult = followPath(value, undefined, path, owner);
+      } catch (err) {
+        // We took ownership of the captures, and there is no callee left to consume them.
+        for (let cap of captures) {
+          cap.dispose();
+        }
+        throw err;
+      }
 
       if (followResult.hook) {
         return followResult.hook.map(followResult.remainingPath, captures, instructions);
@@ -1777,12 +1777,8 @@ abstract class ValueStubHook extends StubHook {
       return mapImpl.applyMap(
           followResult.value, followResult.parent, followResult.owner, captures, instructions);
     } catch (err) {
-      // We took ownership of the captures. If the delegate's map() or applyMap() threw, they
-      // already disposed the captures per the contract, but dispose() is idempotent so disposing
-      // again is harmless.
-      for (let cap of captures) {
-        cap.dispose();
-      }
+      // Past the inner catch, ownership of the captures has been transferred to the delegate's
+      // map() or to applyMap(), so it would be incorrect to dispose them here.
       return new ErrorStubHook(err);
     }
   }

--- a/src/core.ts
+++ b/src/core.ts
@@ -318,8 +318,15 @@ export abstract class StubHook {
 export class ErrorStubHook extends StubHook {
   constructor(private error: any) { super(); }
 
-  call(path: PropertyPath, args: RpcPayload): StubHook { return this; }
-  map(path: PropertyPath, captures: StubHook[], instructions: unknown[]): StubHook { return this; }
+  // call() and map() take ownership of `args` / `captures`; there is no callee here to consume
+  // them, so dispose them before reporting the error.
+  call(path: PropertyPath, args: RpcPayload): StubHook { args.dispose(); return this; }
+  map(path: PropertyPath, captures: StubHook[], instructions: unknown[]): StubHook {
+    for (let cap of captures) {
+      cap.dispose();
+    }
+    return this;
+  }
   get(path: PropertyPath): StubHook { return this; }
   dup(): StubHook { return this; }
   pull(): RpcPayload | Promise<RpcPayload> { return Promise.reject(this.error); }
@@ -1717,6 +1724,8 @@ abstract class ValueStubHook extends StubHook {
         return new PayloadStubHook(payload);
       }));
     } catch (err) {
+      // We took ownership of `args`, and there is no callee left to consume them.
+      args.dispose();
       return new ErrorStubHook(err);
     }
   }
@@ -1993,7 +2002,14 @@ export class PromiseStubHook extends StubHook {
     args.ensureDeepCopied();
 
     return new PromiseStubHook(this.promise.then(
-        hook => hook.call(path, args),
+        hook => {
+          try {
+            return hook.call(path, args);
+          } catch (err) {
+            args.dispose();
+            throw err;
+          }
+        },
         err => {
           args.dispose();
           throw err;
@@ -2007,8 +2023,12 @@ export class PromiseStubHook extends StubHook {
     args.ensureDeepCopied();
     let promise = this.promise.then(
         hook => {
-          let result = hook.stream(path, args);
-          return result.promise;
+          try {
+            return hook.stream(path, args).promise;
+          } catch (err) {
+            args.dispose();
+            throw err;
+          }
         },
         err => {
           args.dispose();

--- a/src/map.ts
+++ b/src/map.ts
@@ -209,12 +209,17 @@ class MapVariableHook extends StubHook {
 
   // Other methods should never be called.
   call(path: PropertyPath, args: RpcPayload): StubHook {
-    // Can't be called; all calls are intercepted.
+    // Can't be called; all calls are intercepted. We still own `args` per the StubHook contract.
+    args.dispose();
     throwMapperBuilderUseError();
   }
 
   map(path: PropertyPath, captures: StubHook[], instructions: unknown[]): StubHook {
-    // Can't be called; all map()s are intercepted.
+    // Can't be called; all map()s are intercepted. We still own the captures per the StubHook
+    // contract.
+    for (let cap of captures) {
+      cap.dispose();
+    }
     throwMapperBuilderUseError();
   }
 

--- a/src/rpc.ts
+++ b/src/rpc.ts
@@ -320,19 +320,22 @@ class RpcImportHook extends StubHook {
     }
   }
 
+  // Like getEntry(), but for use in methods that take ownership of args or captures: if the
+  // entry is gone, there is no callee left to consume them, so dispose them before throwing.
+  private getEntryTakingOwnership(disposeOwned: () => void): ImportTableEntry {
+    try {
+      return this.getEntry();
+    } catch (err) {
+      disposeOwned();
+      throw err;
+    }
+  }
+
   // -------------------------------------------------------------------------------------
   // implements StubHook
 
   call(path: PropertyPath, args: RpcPayload): StubHook {
-    let entry: ImportTableEntry;
-    try {
-      entry = this.getEntry();
-    } catch (err) {
-      // We took ownership of `args`, and there is no callee left to consume them.
-      args.dispose();
-      throw err;
-    }
-
+    let entry = this.getEntryTakingOwnership(() => args.dispose());
     if (entry.resolution) {
       return entry.resolution.call(path, args);
     } else {
@@ -341,15 +344,7 @@ class RpcImportHook extends StubHook {
   }
 
   stream(path: PropertyPath, args: RpcPayload): {promise: Promise<void>, size?: number} {
-    let entry: ImportTableEntry;
-    try {
-      entry = this.getEntry();
-    } catch (err) {
-      // We took ownership of `args`, and there is no callee left to consume them.
-      args.dispose();
-      throw err;
-    }
-
+    let entry = this.getEntryTakingOwnership(() => args.dispose());
     if (entry.resolution) {
       return entry.resolution.stream(path, args);
     } else {
@@ -358,16 +353,11 @@ class RpcImportHook extends StubHook {
   }
 
   map(path: PropertyPath, captures: StubHook[], instructions: unknown[]): StubHook {
-    let entry: ImportTableEntry;
-    try {
-      entry = this.getEntry();
-    } catch (err) {
+    let entry = this.getEntryTakingOwnership(() => {
       for (let cap of captures) {
         cap.dispose();
       }
-      throw err;
-    }
-
+    });
     if (entry.resolution) {
       return entry.resolution.map(path, captures, instructions);
     } else {

--- a/src/rpc.ts
+++ b/src/rpc.ts
@@ -324,7 +324,15 @@ class RpcImportHook extends StubHook {
   // implements StubHook
 
   call(path: PropertyPath, args: RpcPayload): StubHook {
-    let entry = this.getEntry();
+    let entry: ImportTableEntry;
+    try {
+      entry = this.getEntry();
+    } catch (err) {
+      // We took ownership of `args`, and there is no callee left to consume them.
+      args.dispose();
+      throw err;
+    }
+
     if (entry.resolution) {
       return entry.resolution.call(path, args);
     } else {
@@ -333,7 +341,15 @@ class RpcImportHook extends StubHook {
   }
 
   stream(path: PropertyPath, args: RpcPayload): {promise: Promise<void>, size?: number} {
-    let entry = this.getEntry();
+    let entry: ImportTableEntry;
+    try {
+      entry = this.getEntry();
+    } catch (err) {
+      // We took ownership of `args`, and there is no callee left to consume them.
+      args.dispose();
+      throw err;
+    }
+
     if (entry.resolution) {
       return entry.resolution.stream(path, args);
     } else {
@@ -785,18 +801,29 @@ class RpcSessionImpl implements Importer, Exporter {
   }
 
   sendCall(id: ImportId, path: PropertyPath, args?: RpcPayload): RpcImportHook {
-    if (this.abortReason) throw this.abortReason;
+    if (this.abortReason) {
+      args?.dispose();
+      throw this.abortReason;
+    }
 
     let value: Array<any> = ["pipeline", id, path];
     if (args) {
-      let devalue = Devaluator.devaluate(args.value, undefined, this, args, this.encodingLevel);
+      let devalue: unknown;
+      try {
+        devalue = Devaluator.devaluate(args.value, undefined, this, args, this.encodingLevel);
+      } catch (err) {
+        args.dispose();
+        throw err;
+      }
 
       // HACK: Since the args is an array, devaluator will wrap in a second array. Need to unwrap.
       // TODO: Clean this up somehow.
       value.push((<Array<unknown>>devalue)[0]);
 
       // Serializing the payload takes ownership of all stubs within, so the payload itself does
-      // not need to be disposed.
+      // not need to be disposed on success. If serialization threw partway through, disposing
+      // the payload above is safe: any hooks already exported were dups of the payload's hooks,
+      // and the Devaluator rolls back its own export-table entries before rethrowing.
     }
     this.send(["push", value]);
 
@@ -807,10 +834,20 @@ class RpcSessionImpl implements Importer, Exporter {
 
   sendStream(id: ImportId, path: PropertyPath, args: RpcPayload)
       : {promise: Promise<void>, size: number} {
-    if (this.abortReason) throw this.abortReason;
+    if (this.abortReason) {
+      args.dispose();
+      throw this.abortReason;
+    }
 
     let value: Array<any> = ["pipeline", id, path];
-    let devalue = Devaluator.devaluate(args.value, undefined, this, args, this.encodingLevel);
+    let devalue: unknown;
+    try {
+      devalue = Devaluator.devaluate(args.value, undefined, this, args, this.encodingLevel);
+    } catch (err) {
+      // Disposing the partially-serialized payload is safe for the same reasons as in sendCall().
+      args.dispose();
+      throw err;
+    }
 
     // HACK: Since the args is an array, devaluator will wrap in a second array. Need to unwrap.
     // TODO: Clean this up somehow.
@@ -852,6 +889,11 @@ class RpcSessionImpl implements Importer, Exporter {
       throw this.abortReason;
     }
 
+    // Note: This loop cannot throw synchronously after the abortReason check above. getImport()
+    // never throws, and exportStub()'s only throw is its own abortReason check — but aborts are
+    // always deferred to a microtask, so abortReason cannot become set partway through this loop.
+    // (Don't add a dispose() rollback here: exportStub() stores the hook itself, not a dup, in
+    // the export table, so disposing exported captures would corrupt the table.)
     let devaluedCaptures = captures.map(hook => {
       let importId = this.getImport(hook);
       if (importId !== undefined) {


### PR DESCRIPTION
RPC call arguments (and map captures) leaked whenever a call failed before reaching a callee. A rejected pipeline promise, a broken or disposed stub, a failed argument serialization, or a sync throw inside a hook.

Practical example:
```ts
using api = newWebSocketRpcSession<Api>("wss://example.com/api");

let session = api.authenticate(token);       // NOT awaited — returns a promise stub
using uploader = session.getUploader();      // pipelined on the unresolved promise
uploader.write(chunk1, progressCallback);    // pipelined further, passes a capability
uploader.write(chunk2, progressCallback);
```
lets say token is expired so authenticate() rejects.  Every call pipelined behind it had already deep-copied its arguments, including a dup of `progressCallback's hook`. Before this PR, those copies were simply dropped on the rejection path: `progressCallback's` disposer never runs, its entry stays pinned.

Rather than patching each site with caller-side try/catch (as an earlier revision of this PR did), the fix defines the rule once on the abstract `StubHook`: `call()`, `stream()`, and `map()` take ownership of their args/captures even when they throw synchronously, and callers never dispose after invoking. 

The implementations that violated this are fixed
- `RpcImportHook.call()`/`stream()` (including mid-serialization failures, where disposal is safe because exported hooks are dups and the Devaluator rolls back its exports)
- -the default `stream()` (which leaked the result hook when `pull()` threw)
- `MapVariableHook`
- the `map` placeholder

`PromiseStubHook` now disposes its copied args only when its backing promise rejects i.e. where no callee ever existed to take them.

Also kept from the original PR: `PromiseStubHook.dispose()` chains on the backing promise so disposal stays ordered behind already-queued calls.