### PR TITLE
Dispose args when a WritableStream stub call fails

### DIFF
--- a/.changeset/writable-stream-arg-disposal.md
+++ b/.changeset/writable-stream-arg-disposal.md
@@ -1,0 +1,5 @@
+---
+"capnweb": patch
+---
+
+Fix WritableStream stubs leaking call arguments when the stub was already disposed or the call path was invalid. All failure paths in `WritableStreamStubHook.call()` now dispose the copied arguments, matching ReadableStream behavior.

--- a/__tests__/index.test.ts
+++ b/__tests__/index.test.ts
@@ -9,6 +9,7 @@ import { deserialize, serialize, RpcSession, type RpcSessionOptions, RpcTranspor
          newHttpBatchRpcSession} from "../src/index.js"
 import { swapByteOrder } from "../src/serialize.js"
 import { MAX_CLOSE_REASON_BYTES } from "../src/websocket.js"
+import { PromiseStubHook, RpcPayload, streamImpl } from "../src/core.js"
 import { Counter, TestTarget } from "./test-util.js";
 
 type CustomEncodingLevel = RpcTransportWithCustomEncoding["encodingLevel"];
@@ -2792,6 +2793,43 @@ describe("WritableStream over RPC", () => {
     expect(rpcDone).toBe(true);
     expect(rpcError).not.toBeNull();
     expect(rpcError.message).toContain("Simulated write failure");
+  });
+});
+
+describe("WritableStream stub argument disposal", () => {
+  it("disposes copied call arguments when a WritableStream call is invalid", async () => {
+    let disposed = false;
+    class Disposable extends RpcTarget {
+      [Symbol.dispose]() { disposed = true; }
+    }
+
+    let argument = new RpcStub(new Disposable());
+    let hook = new PromiseStubHook(
+        Promise.resolve(streamImpl.createWritableStreamHook(new WritableStream())));
+    let result = hook.call(["not", "a", "method"], RpcPayload.fromAppParams([argument]));
+
+    await expect(result.pull()).rejects.toThrow("only supports direct method calls");
+    argument[Symbol.dispose]();
+    expect(disposed).toBe(true);
+    hook.dispose();
+  });
+
+  it("disposes copied call arguments when the WritableStream stub was disposed", async () => {
+    let disposed = false;
+    class Disposable extends RpcTarget {
+      [Symbol.dispose]() { disposed = true; }
+    }
+
+    let streamHook = streamImpl.createWritableStreamHook(new WritableStream());
+    streamHook.dispose();
+
+    let argument = new RpcStub(new Disposable());
+    let hook = new PromiseStubHook(Promise.resolve(streamHook));
+    let result = hook.call(["write"], RpcPayload.fromAppParams([argument]));
+
+    await expect(result.pull()).rejects.toThrow("after it was disposed");
+    argument[Symbol.dispose]();
+    expect(disposed).toBe(true);
   });
 });
 

--- a/src/streams.ts
+++ b/src/streams.ts
@@ -53,7 +53,6 @@ class WritableStreamStubHook extends StubHook {
       const method = path[0];
 
       if (method !== "write" && method !== "close" && method !== "abort") {
-        args.dispose();
         throw new Error(`Unknown WritableStream method: ${method}`);
       }
 
@@ -69,6 +68,8 @@ class WritableStreamStubHook extends StubHook {
           : args.deliverCall(state.writer[method] as Function, state.writer);
       return new PromiseStubHook(promise.then(payload => new PayloadStubHook(payload)));
     } catch (err) {
+      // We took ownership of `args`, and there is no callee left to consume them.
+      args.dispose();
       return new ErrorStubHook(err);
     }
   }


### PR DESCRIPTION
`WritableStreamStubHook.call()` disposed its copied arguments on the unknown-method path but not when the hook was already disposed or the path shape was invalid. those throws returned an `ErrorStubHook` with the owned arguments stranded. This moves the disposal into the `catch` so every failure path releases them, matching `ReadableStreamStubHook`.

Found while working on the failure-path disposal fixes in #241, but independent of them so it's split out here.