### PR TITLE
fix: create a fresh error per stub disposal for better stack traces

### DIFF
--- a/.changeset/disposed-stub-error-stack.md
+++ b/.changeset/disposed-stub-error-stack.md
@@ -1,0 +1,5 @@
+---
+"capnweb": patch
+---
+
+Errors thrown when using a disposed RPC stub now carry a stack trace pointing at the disposal site instead of at module initialization. Previously all such errors shared a single module-level Error object, which made stack traces useless for debugging use-after-dispose bugs.

--- a/__tests__/index.test.ts
+++ b/__tests__/index.test.ts
@@ -1647,6 +1647,30 @@ describe("map() over RPC", () => {
   });
 });
 
+describe("using a disposed stub", () => {
+  it("rejects calls with an error saying the stub was disposed", async () => {
+    let stub = new RpcStub(new TestTarget());
+    stub[Symbol.dispose]();
+
+    await expect(stub.square(3)).rejects.toThrow("after it has been disposed");
+  });
+
+  it("produces a distinct error for each disposal", async () => {
+    // Each disposal must create a fresh Error so that the stack trace points at the disposal
+    // site rather than at module initialization.
+    let stub1 = new RpcStub(new TestTarget());
+    let stub2 = new RpcStub(new TestTarget());
+    stub1[Symbol.dispose]();
+    stub2[Symbol.dispose]();
+
+    let e1 = await stub1.square(1).then(() => undefined, (e: unknown) => e);
+    let e2 = await stub2.square(2).then(() => undefined, (e: unknown) => e);
+    expect(e1).toBeInstanceOf(Error);
+    expect(e2).toBeInstanceOf(Error);
+    expect(e1).not.toBe(e2);
+  });
+});
+
 describe("stub disposal over RPC", () => {
   it("disposes remote RpcTarget when stub is disposed", async () => {
     let targetDisposedCount = 0;

--- a/src/core.ts
+++ b/src/core.ts
@@ -335,9 +335,6 @@ export class ErrorStubHook extends StubHook {
   }
 };
 
-const DISPOSED_HOOK: StubHook = new ErrorStubHook(
-    new Error("Attempted to use RPC stub after it has been disposed."));
-
 // A call interceptor can be used to intercept all RPC stub invocations within some synchronous
 // scope. This is used to implement record/replay
 type CallInterceptor = (hook: StubHook, path: PropertyPath, params: RpcPayload) => StubHook;
@@ -391,7 +388,10 @@ const PROXY_HANDLERS: ProxyHandler<{raw: RpcStub}> = {
       // We only advertise Symbol.dispose on stubs and root promises, not properties.
       return () => {
         stub.hook.dispose();
-        stub.hook = DISPOSED_HOOK;
+        // Create the error here rather than sharing a singleton so that its stack trace points
+        // at the disposal site, which is what you need to see when debugging a use-after-dispose.
+        stub.hook = new ErrorStubHook(
+            new Error("Attempted to use RPC stub after it has been disposed."));
       };
     } else {
       return undefined;


### PR DESCRIPTION
## Motivation

While investigating production Sentry reports of `Error: Attempted to use RPC stub after it has been disposed.`, we found the error impossible to debug: every occurrence shares a single module-level `Error` object (`DISPOSED_HOOK`), so its stack trace points at capnweb's module initialization rather than anywhere useful. It also collapses all Sentry events into one group regardless of cause.

## Change

Delete the `DISPOSED_HOOK` singleton and create the `ErrorStubHook` (and its `Error`) fresh inside the `Symbol.dispose` disposer. The stack trace now points at the disposal site — the thing you actually need to see when tracking down a use-after-dispose.

- Message text is byte-identical, so existing Sentry grouping/alerting on the message keeps working.
- Allocation cost is one `Error` per explicit dispose — negligible.
- Double-dispose keeps today's semantics (the latest dispose site wins).

## Testing

- New tests: calling a disposed stub rejects with the expected message, and two separate disposals produce distinct error objects (fails against the singleton implementation).
- `npm run build`, `npx vitest run --project node --project workerd` (547 passing), `npm run test:types` all green.
- Manual sanity check against `dist/`: the rejection's stack names the function that disposed the stub.