### PR TITLE
Document TypeScript lib requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,29 @@ Cap'n Web is more expressive than almost every other RPC system, because it impl
 npm i capnweb
 ```
 
+### TypeScript configuration
+
+Cap'n Web's type definitions refer to several recent built-in APIs. If your project sets
+[`compilerOptions.lib`](https://www.typescriptlang.org/tsconfig/#lib) explicitly, use this as a
+baseline:
+
+```json
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["ES2022", "DOM", "ES2024.Promise", "ESNext.Disposable"]
+  }
+}
+```
+
+`ES2024.Promise` provides the types for `Promise.withResolvers()`, while `ESNext.Disposable`
+provides `Disposable`, `Symbol.dispose`, and `Symbol.asyncDispose`. Cap'n Web supplies runtime
+polyfills for those APIs, so the emit target can remain `ES2022`. `DOM` provides the web platform
+types exposed by the main package.
+
+If your project already includes `ESNext`, it covers the Promise and disposable definitions above.
+Keep any additional libraries required by your environment, such as `DOM.Iterable` or `WebWorker`.
+
 ## Example
 
 A client looks like this:

--- a/examples/worker-react/client/tsconfig.json
+++ b/examples/worker-react/client/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "target": "ES2022",
     "useDefineForClassFields": true,
-    "lib": ["ES2024", "DOM", "DOM.Iterable"],
+    "lib": ["ES2022", "DOM", "DOM.Iterable", "ES2024.Promise", "ESNext.Disposable"],
     "module": "ESNext",
     "skipLibCheck": true,
     "moduleResolution": "Bundler",

--- a/examples/worker-react/server/tsconfig.json
+++ b/examples/worker-react/server/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "target": "ES2022",
     "module": "ES2022",
-    "lib": ["ES2022"],
+    "lib": ["ES2022", "ES2024.Promise", "ESNext.Disposable"],
     "types": ["@cloudflare/workers-types"],
     "moduleResolution": "bundler",
     "resolveJsonModule": true,


### PR DESCRIPTION
## Summary

- document the TypeScript target and library definitions required by Cap'n Web's public types
- explain which definitions cover web APIs, Promise.withResolvers(), and explicit resource management
- update the browser and Workers examples to use the documented libraries

## Testing

- npm run build
- npm run test:types
- TypeScript compile for examples/worker-react/client
- TypeScript compile for examples/worker-react/server
- npm run build in examples/worker-react/client
- npm test (34 files, 1,171 tests across Node, Workers, Chromium, Firefox, and WebKit)
- standalone type check with the documented minimum libraries, including an assertion that object results do not resolve to any

Closes #112