### PR TITLE
Add bidirectional WebSocket example

### DIFF
--- a/README.md
+++ b/README.md
@@ -533,6 +533,9 @@ console.log(await stub.greet("Bob"));
 // response back over the wire.
 ```
 
+For a complete example that exposes an RPC interface on both ends of the same connection, see
+[Bidirectional WebSocket calls](examples/websocket-bidirectional/README.md).
+
 ### HTTP server on Cloudflare Workers
 
 The helper function `newWorkersRpcResponse()` makes it easy to implement an HTTP server that accepts both the HTTP batch and WebSocket APIs at once:

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,6 +1,7 @@
 Examples
 
 - batch-pipelining: Node server + client. Shows batching and pipelining to execute a dependent sequence of RPC calls in a single HTTP round trip, with timing vs sequential.
+- websocket-bidirectional: Node server + client. Shows each side exposing an RPC interface over the same WebSocket connection.
 - worker-react: Cloudflare Worker backend + React frontend. Shows the same pattern from a browser app, served by the Worker.
 
 Notes

--- a/examples/websocket-bidirectional/README.md
+++ b/examples/websocket-bidirectional/README.md
@@ -1,0 +1,38 @@
+# Bidirectional WebSocket calls
+
+A WebSocket session can expose an RPC interface on both ends of the connection. The second argument
+to `newWebSocketRpcSession()` is the local interface offered to the peer, and the return value is a
+stub for the peer's interface.
+
+In this example, the client calls `greet()` on the server. Before the server returns the greeting,
+it calls `showNotification()` on the client over the same WebSocket.
+
+Build Cap'n Web from the repository root:
+
+```sh
+npm run build
+```
+
+Start the server:
+
+```sh
+node examples/websocket-bidirectional/server-node.mjs
+```
+
+Then run the client in another terminal:
+
+```sh
+node examples/websocket-bidirectional/client.mjs
+```
+
+The client prints both the server-to-client notification and the response to its original call:
+
+```text
+Notification: The server received Ada.
+Response: Hello, Ada!
+```
+
+The client's local interface remains available for the lifetime of the session. A callback passed
+as a method argument has a shorter default lifetime: if the receiver needs to retain that callback
+after the method returns, it must call `.dup()` as described in
+[Holding on to a callback past the call that delivered it](../../README.md#holding-on-to-a-callback-past-the-call-that-delivered-it).

--- a/examples/websocket-bidirectional/client.mjs
+++ b/examples/websocket-bidirectional/client.mjs
@@ -1,0 +1,21 @@
+// Copyright (c) 2025 Cloudflare, Inc.
+// Licensed under the MIT license found in the LICENSE.txt file or at:
+//     https://opensource.org/license/mit
+
+import { RpcTarget, newWebSocketRpcSession } from "../../dist/index.js";
+
+class ClientApi extends RpcTarget {
+  showNotification(message) {
+    console.log(`Notification: ${message}`);
+  }
+}
+
+// The second argument exposes ClientApi to the server. The return value is a
+// stub for the server's root interface.
+const server = newWebSocketRpcSession("ws://127.0.0.1:8080", new ClientApi());
+
+try {
+  console.log(`Response: ${await server.greet("Ada")}`);
+} finally {
+  server[Symbol.dispose]();
+}

--- a/examples/websocket-bidirectional/server-node.mjs
+++ b/examples/websocket-bidirectional/server-node.mjs
@@ -1,0 +1,31 @@
+// Copyright (c) 2025 Cloudflare, Inc.
+// Licensed under the MIT license found in the LICENSE.txt file or at:
+//     https://opensource.org/license/mit
+
+import { WebSocketServer } from "ws";
+import { RpcTarget, newWebSocketRpcSession } from "../../dist/index.js";
+
+class ServerApi extends RpcTarget {
+  #client;
+
+  static accept(webSocket) {
+    const api = new ServerApi();
+
+    // Expose api to the client and retain the returned stub for the client's
+    // root interface. Closing the WebSocket disposes both sides of the session.
+    api.#client = newWebSocketRpcSession(webSocket, api);
+  }
+
+  async greet(name) {
+    await this.#client.showNotification(`The server received ${name}.`);
+    return `Hello, ${name}!`;
+  }
+}
+
+const webSocketServer = new WebSocketServer({ port: 8080 });
+
+webSocketServer.on("connection", (webSocket) => {
+  ServerApi.accept(webSocket);
+});
+
+console.log("Listening on ws://127.0.0.1:8080");


### PR DESCRIPTION
## Summary

- add a runnable Node client and server that each expose a root RPC interface over one WebSocket
- show the server calling the client's showNotification() method before returning the original greet() call
- connect the WebSocket client guide to the example and point retained method callbacks to the existing .dup() lifecycle guidance

## Testing

- npm run build
- npm run test:types
- npm test (34 files, 1,171 tests across Node, Workers, Chromium, Firefox, and WebKit)
- node --check for both example programs
- end-to-end server and client run with the documented notification and response output

Closes #30