### PR TITLE
feat(rpc): make onRpcBroken registrations disposable

### DIFF
--- a/.changeset/calm-dodos-listen.md
+++ b/.changeset/calm-dodos-listen.md
@@ -1,0 +1,5 @@
+---
+"capnweb": minor
+---
+
+Return a disposable registration from `onRpcBroken()` so callers can stop listening without disposing the stub. Disposing a stub now also removes its registered callbacks.

--- a/README.md
+++ b/README.md
@@ -421,13 +421,17 @@ Note that if you pass the same `RpcTarget` instance to RPC multiple times -- thu
 
 ### Listening for disconnect
 
-You can monitor any stub for "brokenness" with its `onRpcBroken()` method:
+You can monitor any stub for "brokenness" with its `onRpcBroken()` method. It returns a
+`Disposable` registration, which lets you stop listening without disposing the stub:
 
 ```ts
-stub.onRpcBroken((error: any) => {
+using registration = stub.onRpcBroken((error: any) => {
   console.error(error);
 });
 ```
+
+Calling `registration[Symbol.dispose]()` more than once is safe. Disposing the stub also removes
+its registrations without calling them.
 
 If anything happens to the stub that would cause all further method calls and property accesses to throw exceptions, then the callback will be called. In particular, this happens if:
 * The stub's underlying connection is lost.

--- a/__tests__/index.test.ts
+++ b/__tests__/index.test.ts
@@ -9,6 +9,7 @@ import { deserialize, serialize, RpcSession, type RpcSessionOptions, RpcTranspor
          newHttpBatchRpcSession} from "../src/index.js"
 import { swapByteOrder } from "../src/serialize.js"
 import { MAX_CLOSE_REASON_BYTES } from "../src/websocket.js"
+import { ErrorStubHook, PromiseStubHook, type StubHook } from "../src/core.js"
 import { Counter, TestTarget } from "./test-util.js";
 
 type CustomEncodingLevel = RpcTransportWithCustomEncoding["encodingLevel"];
@@ -2110,6 +2111,87 @@ describe("error serialization", () => {
 });
 
 describe("onRpcBroken", () => {
+  it("preserves registration order when a callback disposes a later stub", async () => {
+    class TestBroken extends RpcTarget {
+      makeCounter() { return new Counter(0); }
+      hangingCall(): Promise<void> {
+        return new Promise(() => {});
+      }
+    }
+
+    let harness = new TestHarness(new TestBroken());
+    let first = await harness.stub.makeCounter();
+    let second = await harness.stub.makeCounter();
+    let hangingPromise = harness.stub.hangingCall();
+    let fired: string[] = [];
+
+    first.onRpcBroken(() => {
+      fired.push("first");
+      second[Symbol.dispose]();
+    });
+    second.onRpcBroken(() => { fired.push("second"); });
+
+    harness.clientTransport.forceReceiveError(new Error("test disconnect"));
+    await hangingPromise.catch(() => {});
+
+    expect(fired).toStrictEqual(["first", "second"]);
+  });
+
+  it("unregisters from a deferred hook when its promise stub is disposed", async () => {
+    let deferred = Promise.withResolvers<StubHook>();
+    let hook = new PromiseStubHook(deferred.promise);
+    let errors: unknown[] = [];
+
+    hook.onBroken(error => { errors.push(error); });
+    hook.dispose();
+    deferred.resolve(new ErrorStubHook(new Error("late failure")));
+    await deferred.promise;
+    await pumpMicrotasks();
+
+    expect(errors).toStrictEqual([]);
+  });
+
+  it("returns disposable registrations and removes them with their stub", async () => {
+    class TestBroken extends RpcTarget {
+      makeCounter() { return new Counter(0); }
+      hangingCall(): Promise<Counter> {
+        return new Promise(() => {});
+      }
+    }
+
+    let harness = new TestHarness(new TestBroken());
+    let stub = harness.stub;
+    let fired: string[] = [];
+
+    let duplicateCallback = () => { fired.push("duplicate"); };
+    let removedDuplicate = stub.onRpcBroken(duplicateCallback);
+    let keptDuplicate = stub.onRpcBroken(duplicateCallback);
+    expect(Symbol.dispose in removedDuplicate).toBe(true);
+    removedDuplicate[Symbol.dispose]();
+    expect(() => removedDuplicate[Symbol.dispose]()).not.toThrow();
+
+    let counterPromise = stub.makeCounter();
+    let forwardedRegistration = counterPromise.onRpcBroken(() => { fired.push("forwarded"); });
+    let counter = await counterPromise;
+    forwardedRegistration[Symbol.dispose]();
+    expect(() => forwardedRegistration[Symbol.dispose]()).not.toThrow();
+    counter[Symbol.dispose]();
+
+    let hangingPromise = stub.hangingCall();
+    let pendingRegistration = hangingPromise.onRpcBroken(() => { fired.push("pending"); });
+    pendingRegistration[Symbol.dispose]();
+
+    let disposedStub = await stub.makeCounter();
+    disposedStub.onRpcBroken(() => { fired.push("disposed stub"); });
+    disposedStub[Symbol.dispose]();
+
+    harness.clientTransport.forceReceiveError(new Error("test disconnect"));
+    await hangingPromise.catch(() => {});
+
+    expect(fired).toStrictEqual(["duplicate"]);
+    expect(() => keptDuplicate[Symbol.dispose]()).not.toThrow();
+  });
+
   it("signals when the connection is lost", async () => {
     class TestBroken extends RpcTarget {
       getValue() { return 42; }
@@ -2152,11 +2234,14 @@ describe("onRpcBroken", () => {
     ]);
 
     // onRpcBroken() when already broken just reports the error immediately.
-    throwingPromise.onRpcBroken(error => { errors.push({which: "throwError2", error}); });
+    let brokenRegistration = throwingPromise.onRpcBroken(
+        error => { errors.push({which: "throwError2", error}); });
     expect(errors).toStrictEqual([
       {which: "throwError", error: new Error("test error")},
       {which: "throwError2", error: new Error("test error")},
     ]);
+    expect(() => brokenRegistration[Symbol.dispose]()).not.toThrow();
+    expect(() => brokenRegistration[Symbol.dispose]()).not.toThrow();
 
     // Simulate disconnect by making the transport fail
     harness.clientTransport.forceReceiveError(new Error("test disconnect"));

--- a/__type-tests__/rpc-promise-semantics.test.ts
+++ b/__type-tests__/rpc-promise-semantics.test.ts
@@ -63,9 +63,9 @@ expectType<RpcPromise<string>>(namePromise)
 expectType<RpcPromise<number>>(idPromise)
 expectType<RpcPromise<Counter>>(nestedCounterPromise)
 
-userPromise.onRpcBroken((_error) => {})
-counterPromise.onRpcBroken((_error) => {})
-idPromise.onRpcBroken((_error) => {})
+expectType<Disposable>(userPromise.onRpcBroken((_error) => {}))
+expectType<Disposable>(counterPromise.onRpcBroken((_error) => {}))
+expectType<Disposable>(idPromise.onRpcBroken((_error) => {}))
 
 expectAssignable<Promise<number>>(counterPromise.increment(3))
 expectAssignable<Promise<number>>(counterPromise.value)

--- a/packages/capnweb-validate/src/internal/core.ts
+++ b/packages/capnweb-validate/src/internal/core.ts
@@ -56,7 +56,7 @@ type WrapSide = "server" | "client";
 
 interface StubBase<T = unknown> extends Disposable {
   dup(): this;
-  onRpcBroken(callback: (error: unknown) => void): void;
+  onRpcBroken(callback: (error: unknown) => void): Disposable;
   readonly __RPC_STUB_BRAND: T;
 }
 

--- a/src/core.ts
+++ b/src/core.ts
@@ -4,14 +4,7 @@
 
 import type { RpcTargetBranded, __RPC_TARGET_BRAND } from "./types.js";
 import { WORKERS_MODULE_SYMBOL } from "./symbols.js"
-
-// Polyfill Symbol.dispose for browsers that don't support it yet
-if (!Symbol.dispose) {
-  (Symbol as any).dispose = Symbol.for('dispose');
-}
-if (!Symbol.asyncDispose) {
-  (Symbol as any).asyncDispose = Symbol.for('asyncDispose');
-}
+import { DeferredDisposable, makeDisposable, NOOP_DISPOSABLE } from "./disposable.js";
 
 // Polyfill Promise.withResolvers() for old Safari versions (ugh), Hermes (React Native), and
 // maybe others.
@@ -312,7 +305,7 @@ export abstract class StubHook {
   // a disposed payload) or it may reject. It's safe to call dispose() multiple times.
   abstract dispose(): void;
 
-  abstract onBroken(callback: (error: any) => void): void;
+  abstract onBroken(callback: (error: any) => void): Disposable;
 }
 
 export class ErrorStubHook extends StubHook {
@@ -325,13 +318,14 @@ export class ErrorStubHook extends StubHook {
   pull(): RpcPayload | Promise<RpcPayload> { return Promise.reject(this.error); }
   ignoreUnhandledRejections(): void {}
   dispose(): void {}
-  onBroken(callback: (error: any) => void): void {
+  onBroken(callback: (error: any) => void): Disposable {
     try {
       callback(this.error);
     } catch (err) {
       // Don't throw back into the RPC system. Treat this as an unhandled rejection.
       Promise.resolve(err);
     }
+    return NOOP_DISPOSABLE;
   }
 };
 
@@ -519,8 +513,8 @@ export class RpcStub extends RpcTarget {
     }
   }
 
-  onRpcBroken(callback: (error: any) => void) {
-    this[RAW_STUB].hook.onBroken(callback);
+  onRpcBroken(callback: (error: any) => void): Disposable {
+    return this[RAW_STUB].hook.onBroken(callback);
   }
 
   map(func: (value: RpcPromise) => unknown): RpcPromise {
@@ -1843,17 +1837,18 @@ export class PayloadStubHook extends ValueStubHook {
     }
   }
 
-  onBroken(callback: (error: any) => void): void {
+  onBroken(callback: (error: any) => void): Disposable {
     if (this.payload) {
       if (this.payload.value instanceof RpcStub) {
         // Payload is a single stub, we should forward onRpcBroken to it.
         // TODO: Consider prohibiting PayloadStubHook created around a single stub; should always
         //   use the underlying stub's hook instead?
-        this.payload.value.onRpcBroken(callback);
+        return this.payload.value.onRpcBroken(callback);
       }
 
       // TODO: Should native stubs be able to implement onRpcBroken?
     }
+    return NOOP_DISPOSABLE;
   }
 }
 
@@ -1964,8 +1959,9 @@ class TargetStubHook extends ValueStubHook {
     }
   }
 
-  onBroken(callback: (error: any) => void): void {
+  onBroken(callback: (error: any) => void): Disposable {
     // TODO: Should RpcTargets be able to implement onRpcBroken?
+    return NOOP_DISPOSABLE;
   }
 }
 
@@ -1974,6 +1970,7 @@ class TargetStubHook extends ValueStubHook {
 export class PromiseStubHook extends StubHook {
   private promise: Promise<StubHook>;
   private resolution: StubHook | undefined;
+  private onBrokenRegistrations?: Set<Disposable>;
 
   constructor(promise: Promise<StubHook>) {
     super();
@@ -2056,6 +2053,7 @@ export class PromiseStubHook extends StubHook {
   }
 
   dispose(): void {
+    this.disposeOnBrokenRegistrations();
     if (this.resolution) {
       this.resolution.dispose();
     } else {
@@ -2067,13 +2065,42 @@ export class PromiseStubHook extends StubHook {
     }
   }
 
-  onBroken(callback: (error: any) => void): void {
+  onBroken(callback: (error: any) => void): Disposable {
     if (this.resolution) {
-      this.resolution.onBroken(callback);
+      return this.trackOnBrokenRegistration(this.resolution.onBroken(callback));
     } else {
+      let registration = new DeferredDisposable();
       this.promise.then(hook => {
-        hook.onBroken(callback);
-      }, callback);
+        if (!registration.isDisposed) {
+          registration.set(hook.onBroken(callback));
+        }
+      }, error => {
+        if (!registration.isDisposed) {
+          registration.set(new ErrorStubHook(error).onBroken(callback));
+        }
+      });
+      return this.trackOnBrokenRegistration(registration);
+    }
+  }
+
+  private trackOnBrokenRegistration(inner: Disposable): Disposable {
+    let handle: Disposable;
+    handle = makeDisposable(() => {
+      inner[Symbol.dispose]();
+      this.onBrokenRegistrations?.delete(handle);
+    });
+    if (!this.onBrokenRegistrations) this.onBrokenRegistrations = new Set();
+    this.onBrokenRegistrations.add(handle);
+    return handle;
+  }
+
+  private disposeOnBrokenRegistrations(): void {
+    let registrations = this.onBrokenRegistrations;
+    this.onBrokenRegistrations = undefined;
+    if (registrations) {
+      for (let registration of registrations) {
+        registration[Symbol.dispose]();
+      }
     }
   }
 }

--- a/src/disposable.ts
+++ b/src/disposable.ts
@@ -1,0 +1,56 @@
+// Copyright (c) 2026 Cloudflare, Inc.
+// Licensed under the MIT license found in the LICENSE.txt file or at:
+//     https://opensource.org/license/mit
+
+// Install these before defining computed Symbol.dispose methods below. Browsers without Explicit
+// Resource Management would otherwise create the handles with an undefined property key.
+if (!Symbol.dispose) {
+  (Symbol as any).dispose = Symbol.for('dispose');
+}
+if (!Symbol.asyncDispose) {
+  (Symbol as any).asyncDispose = Symbol.for('asyncDispose');
+}
+
+export const NOOP_DISPOSABLE: Disposable = {
+  [Symbol.dispose]() {}
+};
+
+export function makeDisposable(callback: () => void): Disposable {
+  let active = true;
+  return {
+    [Symbol.dispose]() {
+      if (active) {
+        active = false;
+        callback();
+      }
+    }
+  };
+}
+
+// A disposable whose implementation may become available later, such as an onRpcBroken()
+// registration made on an unresolved promise. If it is disposed before set() is called, the
+// eventual implementation is disposed immediately.
+export class DeferredDisposable implements Disposable {
+  private inner?: Disposable;
+  private disposed = false;
+
+  get isDisposed(): boolean {
+    return this.disposed;
+  }
+
+  set(inner: Disposable): void {
+    if (this.disposed) {
+      inner[Symbol.dispose]();
+    } else {
+      this.inner = inner;
+    }
+  }
+
+  [Symbol.dispose](): void {
+    if (!this.disposed) {
+      this.disposed = true;
+      this.inner?.[Symbol.dispose]();
+      this.inner = undefined;
+    }
+  }
+}

--- a/src/map.ts
+++ b/src/map.ts
@@ -227,7 +227,7 @@ class MapVariableHook extends StubHook {
     // Probably never called but whatever.
   }
 
-  onBroken(callback: (error: any) => void): void {
+  onBroken(callback: (error: any) => void): Disposable {
     throwMapperBuilderUseError();
   }
 }

--- a/src/rpc.ts
+++ b/src/rpc.ts
@@ -4,6 +4,7 @@
 
 import { StubHook, RpcPayload, RpcStub, PropertyPath, PayloadStubHook, ErrorStubHook, RpcTarget, unwrapStubAndPath, streamImpl } from "./core.js";
 import { Devaluator, Evaluator, ExportId, ImportId, Exporter, Importer, serialize, EncodingLevel, RpcLimits, DEFAULT_LIMITS } from "./serialize.js";
+import { DeferredDisposable, makeDisposable, NOOP_DISPOSABLE } from "./disposable.js";
 
 /**
  * Interface for a string-based RPC transport. This is the default transport type — no
@@ -178,6 +179,11 @@ type ExportTableEntry = {
   pipeReadable?: ReadableStream
 };
 
+type OnBrokenRegistration = {
+  index: number;
+  handle: DeferredDisposable;
+};
+
 // Entry on the imports table.
 class ImportTableEntry {
   constructor(public session: RpcSessionImpl, public importId: number, pulling: boolean) {
@@ -192,9 +198,9 @@ class ImportTableEntry {
   private activePull?: PromiseWithResolvers<void>;
   public resolution?: StubHook;
 
-  // List of integer indexes into session.onBrokenCallbacks which are callbacks registered on
-  // this import. Initialized on first use (so `undefined` is the same as an empty list).
-  private onBrokenRegistrations?: number[];
+  // Registrations made on this unresolved import, including their indexes in the session's
+  // callback array. Initialized on first use (so `undefined` is the same as an empty list).
+  private onBrokenRegistrations?: OnBrokenRegistration[];
 
   resolve(resolution: StubHook) {
     // TODO: Need embargo handling here? PayloadStubHook needs to be wrapped in a
@@ -217,20 +223,23 @@ class ImportTableEntry {
     if (this.onBrokenRegistrations) {
       // Delete all our callback registrations from this session and re-register them on the
       // target stub.
-      for (let i of this.onBrokenRegistrations) {
-        let callback = this.session.onBrokenCallbacks[i];
+      for (let registration of this.onBrokenRegistrations) {
+        let callback = this.session.onBrokenCallbacks[registration.index];
+        if (!callback) continue;
+
         let endIndex = this.session.onBrokenCallbacks.length;
-        resolution.onBroken(callback);
+        let forwarded = resolution.onBroken(callback);
         if (this.session.onBrokenCallbacks[endIndex] === callback) {
           // Oh, calling onBroken() just registered the callback back on this connection again.
           // But when the connection dies, we want all the callbacks to be called in the order in
           // which they were registered. So we don't want this one pushed to the back of the line
           // here. So, let's remove the newly-added registration and keep the original.
           // TODO: This is quite hacky, think about whether this is really the right answer.
-          delete this.session.onBrokenCallbacks[endIndex];
+          forwarded[Symbol.dispose]();
         } else {
           // The callback is now registered elsewhere, so delete it from our session.
-          delete this.session.onBrokenCallbacks[i];
+          delete this.session.onBrokenCallbacks[registration.index];
+          registration.handle.set(forwarded);
         }
       }
       this.onBrokenRegistrations = undefined;
@@ -271,19 +280,46 @@ class ImportTableEntry {
 
       // The RpcSession itself will have called all our callbacks so we don't need to track the
       // registrations anymore.
+      if (this.onBrokenRegistrations) {
+        let sessionAborting = this.session.isAborted();
+        for (let registration of this.onBrokenRegistrations) {
+          // During session abort, an earlier callback may dispose a stub whose callback has not
+          // run yet. Keep its slot until the session finishes iterating the callback array.
+          if (!sessionAborting) {
+            delete this.session.onBrokenCallbacks[registration.index];
+          }
+          registration.handle.set(NOOP_DISPOSABLE);
+        }
+      }
       this.onBrokenRegistrations = undefined;
     }
   }
 
-  onBroken(callback: (error: any) => void): void {
+  onBroken(callback: (error: any) => void): Disposable {
     if (this.resolution) {
-      this.resolution.onBroken(callback);
+      return this.resolution.onBroken(callback);
     } else {
       let index = this.session.onBrokenCallbacks.length;
       this.session.onBrokenCallbacks.push(callback);
 
       if (!this.onBrokenRegistrations) this.onBrokenRegistrations = [];
-      this.onBrokenRegistrations.push(index);
+      let handle = new DeferredDisposable();
+      let registration = {index, handle};
+      handle.set(makeDisposable(() => {
+        // Once abort has started, preserve the callback array until RpcSessionImpl finishes
+        // dispatching it. An earlier callback may dispose the stub for a later callback.
+        if (!this.session.isAborted()) {
+          delete this.session.onBrokenCallbacks[index];
+        }
+        let registrations = this.onBrokenRegistrations;
+        if (registrations) {
+          let registrationIndex = registrations.indexOf(registration);
+          if (registrationIndex !== -1) registrations.splice(registrationIndex, 1);
+          if (registrations.length === 0) this.onBrokenRegistrations = undefined;
+        }
+      }));
+      this.onBrokenRegistrations.push(registration);
+      return handle;
     }
   }
 
@@ -297,6 +333,7 @@ class ImportTableEntry {
 
 class RpcImportHook extends StubHook {
   public entry?: ImportTableEntry;  // undefined when we're disposed
+  private onBrokenRegistrations?: Set<Disposable>;
 
   // `pulling` is true if we already expect that this import is going to be resolved later, and
   // null if this import is not allowed to be pulled (i.e. it's a stub not a promise).
@@ -393,6 +430,7 @@ class RpcImportHook extends StubHook {
   }
 
   dispose(): void {
+    this.disposeOnBrokenRegistrations();
     let entry = this.entry;
     this.entry = undefined;
     if (entry) {
@@ -402,9 +440,28 @@ class RpcImportHook extends StubHook {
     }
   }
 
-  onBroken(callback: (error: any) => void): void {
+  onBroken(callback: (error: any) => void): Disposable {
     if (this.entry) {
-      this.entry.onBroken(callback);
+      let inner = this.entry.onBroken(callback);
+      let handle: Disposable;
+      handle = makeDisposable(() => {
+        inner[Symbol.dispose]();
+        this.onBrokenRegistrations?.delete(handle);
+      });
+      if (!this.onBrokenRegistrations) this.onBrokenRegistrations = new Set();
+      this.onBrokenRegistrations.add(handle);
+      return handle;
+    }
+    return NOOP_DISPOSABLE;
+  }
+
+  protected disposeOnBrokenRegistrations(): void {
+    let registrations = this.onBrokenRegistrations;
+    this.onBrokenRegistrations = undefined;
+    if (registrations) {
+      for (let registration of registrations) {
+        registration[Symbol.dispose]();
+      }
     }
   }
 }
@@ -418,6 +475,7 @@ class RpcMainHook extends RpcImportHook {
   }
 
   dispose(): void {
+    this.disposeOnBrokenRegistrations();
     if (this.session) {
       let session = this.session;
       this.session = undefined;
@@ -514,6 +572,10 @@ class RpcSessionImpl implements Importer, Exporter {
     this.imports.push(new ImportTableEntry(this, 0, false));
 
     this.readLoop().catch(err => this.abort(err));
+  }
+
+  isAborted(): boolean {
+    return this.abortReason !== undefined;
   }
 
   // Should only be called once immediately after construction.
@@ -940,6 +1002,7 @@ class RpcSessionImpl implements Importer, Exporter {
         Promise.resolve(err);
       }
     }
+    this.onBrokenCallbacks = [];
     for (let i in this.imports) {
       this.imports[i].abort(error);
     }

--- a/src/streams.ts
+++ b/src/streams.ts
@@ -5,6 +5,7 @@
 import {
   StubHook, RpcPayload, PropertyPath, ErrorStubHook, PayloadStubHook, PromiseStubHook, streamImpl
 } from "./core.js";
+import { NOOP_DISPOSABLE } from "./disposable.js";
 
 // =======================================================================================
 // WritableStreamStubHook - wraps a local WritableStream for export
@@ -115,9 +116,10 @@ class WritableStreamStubHook extends StubHook {
     }
   }
 
-  onBroken(callback: (error: any) => void): void {
+  onBroken(callback: (error: any) => void): Disposable {
     // WritableStream stubs don't really have a "broken" state in the same way.
     // The caller would notice when write/close/abort fails.
+    return NOOP_DISPOSABLE;
   }
 }
 
@@ -517,8 +519,9 @@ class ReadableStreamStubHook extends StubHook {
     }
   }
 
-  onBroken(callback: (error: any) => void): void {
+  onBroken(callback: (error: any) => void): Disposable {
     // ReadableStream stubs don't have a "broken" state.
+    return NOOP_DISPOSABLE;
   }
 }
 

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -54,7 +54,7 @@ export type RpcCompatible<T> =
 interface StubBase<T = unknown> extends Disposable {
   [__RPC_STUB_BRAND]: T;
   dup(): this;
-  onRpcBroken(callback: (error: any) => void): void;
+  onRpcBroken(callback: (error: any) => void): Disposable;
 }
 export type Stub<T extends RpcCompatible<T>> =
     T extends object ? Provider<T> & StubBase<T> : StubBase<T>;


### PR DESCRIPTION
## Summary

- return an idempotent `Disposable` from `onRpcBroken()`
- unregister callbacks when their handle or owning stub is disposed, including unresolved promise and import hooks
- preserve callback order when a callback disposes a later stub during session abort
- update the public and validation types, README, tests, and changeset

## Testing

- `npm run build`
- `npm run test:types`
- `npm test -- --project=node __tests__/index.test.ts`
- the new tests pass in Node, workerd, Chromium, Firefox, and WebKit
- `npm test`: 1,188 of 1,189 tests pass locally; the existing WebKit `applies backpressure when window fills up` test times out in the full file on both this branch and a clean `origin/main`, while passing in isolation

Closes #234
Closes #210
