### PR TITLE
fix: methods returning Promise<RpcStub<T>> no longer produce stub-of-stub result types

### DIFF
--- a/.changeset/result-stub-elision.md
+++ b/.changeset/result-stub-elision.md
@@ -1,0 +1,6 @@
+---
+"capnweb": minor
+"capnweb-validate": minor
+---
+
+Fixed methods declared to return `Promise<RpcStub<T>>` producing broken stub-of-stub result types; they now type the same as `Promise<T>`. If you annotated such a result as `RpcPromise<RpcStub<T>>`, write `RpcPromise<T>` instead.

--- a/__tests__/workerd.test.ts
+++ b/__tests__/workerd.test.ts
@@ -147,9 +147,7 @@ describe("workerd compatibility", () => {
   })
 
   it("can wrap a userspace stub in a native stub", async () => {
-    // Cast: now that the `__RPC_TARGET_BRAND` no longer leaks onto stub surfaces, a userspace
-    // stub doesn't statically match workers-types' `Stubable` (runtime interop still works).
-    let stub = new NativeRpcStub(<any>new RpcStub(new JsCounter()));
+    let stub = new NativeRpcStub(new RpcStub(new JsCounter()));
     expect(await stub.increment()).toBe(1);
     expect(await stub.increment()).toBe(2);
 
@@ -182,7 +180,7 @@ describe("workerd compatibility", () => {
     // Wrap a userspace RpcPromise in a native stub.
     {
       let factory = new RpcStub(new CounterFactory());
-      let stub = new NativeRpcStub(<any>factory.getJs());  // cast: see "userspace stub" above
+      let stub = new NativeRpcStub(factory.getJs());
       expect(await stub.increment()).toBe(1);
       expect(await stub.increment()).toBe(2);
 
@@ -192,7 +190,7 @@ describe("workerd compatibility", () => {
     // Wrap a userspace property (which is actually also an RpcPromise) in a native stub.
     {
       let factory = new RpcStub(new CounterFactory());
-      let stub = new NativeRpcStub(<any>factory.getJsEmbedded().stub);  // cast: see above
+      let stub = new NativeRpcStub(factory.getJsEmbedded().stub);
       expect(await stub.increment()).toBe(1);
       expect(await stub.increment()).toBe(2);
 

--- a/__tests__/workerd.test.ts
+++ b/__tests__/workerd.test.ts
@@ -147,7 +147,9 @@ describe("workerd compatibility", () => {
   })
 
   it("can wrap a userspace stub in a native stub", async () => {
-    let stub = new NativeRpcStub(new RpcStub(new JsCounter()));
+    // Cast: now that the `__RPC_TARGET_BRAND` no longer leaks onto stub surfaces, a userspace
+    // stub doesn't statically match workers-types' `Stubable` (runtime interop still works).
+    let stub = new NativeRpcStub(<any>new RpcStub(new JsCounter()));
     expect(await stub.increment()).toBe(1);
     expect(await stub.increment()).toBe(2);
 
@@ -180,7 +182,7 @@ describe("workerd compatibility", () => {
     // Wrap a userspace RpcPromise in a native stub.
     {
       let factory = new RpcStub(new CounterFactory());
-      let stub = new NativeRpcStub(factory.getJs());
+      let stub = new NativeRpcStub(<any>factory.getJs());  // cast: see "userspace stub" above
       expect(await stub.increment()).toBe(1);
       expect(await stub.increment()).toBe(2);
 
@@ -190,7 +192,7 @@ describe("workerd compatibility", () => {
     // Wrap a userspace property (which is actually also an RpcPromise) in a native stub.
     {
       let factory = new RpcStub(new CounterFactory());
-      let stub = new NativeRpcStub(factory.getJsEmbedded().stub);
+      let stub = new NativeRpcStub(<any>factory.getJsEmbedded().stub);  // cast: see above
       expect(await stub.increment()).toBe(1);
       expect(await stub.increment()).toBe(2);
 

--- a/__type-tests__/capnweb-validate.test.ts
+++ b/__type-tests__/capnweb-validate.test.ts
@@ -1,6 +1,6 @@
 import { RpcTarget, type RpcCompatible } from "../src/index.js"
 import { validateStub, type ValidatedStub } from "../packages/capnweb-validate/src/index.js"
-import { expectAssignable, expectType, type Expect } from "./helpers.js"
+import { expectAssignable, expectType, type Equal, type Expect } from "./helpers.js"
 
 class Counter extends RpcTarget {
   increment(by: number): number {
@@ -33,9 +33,99 @@ api.getPair().then((pair) => {
   void mutablePair
 })
 
+// Stub elision mirrors the main package: a `Promise<ValidatedStub<T>>` return for a branded
+// target produces the same type as a `Promise<T>` return, while plain-interface stubs keep
+// the non-elided shape (they only await back to a stub when NOT elided).
+type Formatter = (x: number) => string
+
+interface StubReturningApi {
+  viaTarget(): Promise<Counter>
+  viaStub(): Promise<ValidatedStub<Counter>>
+  viaFn(): Promise<Formatter>
+  viaFnStub(): Promise<ValidatedStub<Formatter>>
+  getPlain(): Promise<ValidatedStub<Api>>
+  getAnyStub(): Promise<ValidatedStub<any>>
+  getAny(): Promise<any>
+  getUnknown(): Promise<unknown>
+  maybeStub(): Promise<ValidatedStub<Counter> | null>
+  consumeMaybe(counter: ValidatedStub<Counter> | null): Promise<number>
+  dies(): Promise<never>
+}
+
+// The brand-leak fix, mirrored: a validated stub of a branded target must not itself look
+// branded, or `Stubify` would double-wrap it.
+type _NoBrandLeak = Expect<
+  Equal<ValidatedStub<Counter> extends { readonly __RPC_TARGET_BRAND: never } ? true : false, false>
+>
+
+let stubApi = validateStub<StubReturningApi>(rawStub)
+
+const viaTarget = stubApi.viaTarget()
+const viaStub = stubApi.viaStub()
+type _ValidatedStubElides = Expect<Equal<typeof viaStub, typeof viaTarget>>
+expectAssignable<Promise<number>>(viaStub.increment(2))
+
+// Callable stubs elide too.
+const fnViaTarget = stubApi.viaFn()
+const fnViaStub = stubApi.viaFnStub()
+type _ValidatedCallableStubElides = Expect<Equal<typeof fnViaStub, typeof fnViaTarget>>
+
+// A `never`-returning method stays `never` instead of matching the promise-normalization arm
+// with `U = unknown`.
+const neverResult = stubApi.dies()
+type _NeverStaysNever = Expect<Equal<typeof neverResult, never>>
+
+// Elision distributes over unions, so a `ValidatedStub<T> | null` result still passes as a
+// pipelined argument.
+const maybe = stubApi.maybeStub()
+stubApi.consumeMaybe(maybe)
+
+// Promise-backed stub results normalize: re-declaring a method as returning another method's
+// result type produces that same type.
+interface ChainApi {
+  chain(): typeof viaTarget
+}
+let chainApi = validateStub<ChainApi>(rawStub)
+const chained = chainApi.chain()
+type _RpcPromiseNormalizes = Expect<Equal<typeof chained, typeof viaTarget>>
+
+const plainStubPromise = stubApi.getPlain()
+
+async function assertValidatedStubShapes() {
+  const awaitedCounter = await viaStub
+  expectAssignable<Promise<number>>(awaitedCounter.increment(1))
+
+  // Plain-interface stubs keep the wrapper: awaiting still yields the stub itself.
+  const inner: ValidatedStub<Api> = await plainStubPromise
+  expectAssignable<Promise<number>>(inner.getCounter().increment(1))
+
+  // Union elision: awaiting yields the payload stub or null.
+  const maybeCounter = await maybe
+  if (maybeCounter !== null) {
+    expectAssignable<Promise<number>>(maybeCounter.increment(1))
+  } else {
+    expectType<null>(maybeCounter)
+  }
+
+  // `any` and `unknown` payloads must keep the full stub-result surface: `[any] extends [X]`
+  // is true for any `X`, so without the IsAny guards these would collapse to
+  // `Promise<unknown> & StubBase<unknown>`.
+  const anyStubResult = stubApi.getAnyStub()
+  const anyResult = stubApi.getAny()
+  expectAssignable<Disposable>(anyStubResult)
+  expectAssignable<Disposable>(anyResult)
+  expectAssignable<Disposable>(stubApi.getUnknown())
+  anyStubResult.dup()
+  anyResult.onRpcBroken((_error) => {})
+}
+
+void assertValidatedStubShapes
+
 // @ts-expect-error wrong method name
 api.missing()
 // @ts-expect-error wrong argument type
 counter.increment("1")
 // @ts-expect-error array elements must be numbers
 api.sum(["1"])
+// @ts-expect-error pipelined methods keep signatures on elided stub returns
+viaStub.increment("2")

--- a/__type-tests__/stub-elision.test.ts
+++ b/__type-tests__/stub-elision.test.ts
@@ -1,0 +1,132 @@
+// Declared stub returns/properties (`Promise<RpcStub<T>>`, `RpcStub<T>`) must produce the same
+// `RpcPromise<T>` as returning the payload directly (`Promise<T>`). Plain-interface stubs are
+// the exception: they are NOT elided, because `RpcPromise<U>` only awaits back to a stub when
+// `U` is Stubable.
+import { RpcPromise, RpcStub, RpcTarget } from "../src/index.js"
+import type { Stubable } from "../src/types.js"
+import { expectAssignable, expectType, type Equal, type Expect } from "./helpers.js"
+
+class Counter extends RpcTarget {
+  increment(by: number): number {
+    return by
+  }
+
+  get value(): number {
+    return 0
+  }
+}
+
+type Formatter = (x: number) => string
+
+interface PlainApi {
+  ping(): number
+  echo(name: string): Promise<string>
+}
+
+interface ElisionApi {
+  viaTarget(): Promise<Counter>
+  viaStub(): Promise<RpcStub<Counter>>
+  counterProp: RpcStub<Counter>
+  viaFn(): Promise<Formatter>
+  viaFnStub(): Promise<RpcStub<Formatter>>
+  wrapped(): Promise<{ s: RpcStub<Counter> }>
+  listStubs(): Promise<RpcStub<Counter>[]>
+  consumeCounter(counter: RpcStub<Counter>): Promise<number>
+  getApi(): Promise<RpcStub<PlainApi>>
+  getAnyStub(): Promise<RpcStub<any>>
+  anyStubProp: RpcStub<any>
+  maybeStub(): Promise<RpcStub<Counter> | null>
+  consumeMaybe(counter: RpcStub<Counter> | null): Promise<number>
+}
+
+// The brand-leak fix: a stub of a branded target no longer matches `Stubable` structurally
+// (the string-keyed brand is excluded from the stub's surface), which is the root cause of
+// double-stubification. Callable stubs remain `Stubable` — they are genuinely callable —
+// which is why `Stubify` checks `StubBase` before `Stubable`.
+type _BrandedStubIsNotStubable = Expect<Equal<RpcStub<Counter> extends Stubable ? true : false, false>>
+type _CallableStubIsStillStubable = Expect<Equal<RpcStub<Formatter> extends Stubable ? true : false, true>>
+
+declare const api: RpcStub<ElisionApi>
+
+// 1. A `Promise<RpcStub<T>>` return is indistinguishable from a `Promise<T>` return.
+const viaTarget = api.viaTarget()
+const viaStub = api.viaStub()
+type _StubReturnMatchesTargetReturn = Expect<Equal<typeof viaStub, typeof viaTarget>>
+expectType<RpcPromise<Counter>>(viaStub)
+
+// 2. Both forms can be passed as pipelined RPC arguments (previously TS2345 for viaStub).
+api.consumeCounter(viaTarget)
+api.consumeCounter(viaStub)
+
+// 3. Awaiting yields a single stub, not a stub-of-stub (previously TS2322).
+type _AwaitedViaStub = Expect<Equal<Awaited<typeof viaStub>, RpcStub<Counter>>>
+
+// Pipelining on the elided promise works like any other RpcPromise<Counter>.
+expectAssignable<Promise<number>>(viaStub.increment(3))
+expectAssignable<Promise<number>>(viaStub.value)
+viaStub.onRpcBroken((_error) => {})
+
+// 5. An interface property typed `RpcStub<T>` elides identically.
+const propPromise = api.counterProp
+type _PropertyElides = Expect<Equal<typeof propPromise, typeof viaTarget>>
+
+// 6. Callable stubs (`RpcStub<(x: number) => string>`) elide too — the second Stubable path.
+const fnViaTarget = api.viaFn()
+const fnViaStub = api.viaFnStub()
+type _CallableStubElides = Expect<Equal<typeof fnViaStub, typeof fnViaTarget>>
+type _AwaitedFnStub = Expect<Equal<Awaited<typeof fnViaStub>, RpcStub<Formatter>>>
+expectAssignable<Promise<string>>(fnViaStub(4))
+
+// 7. Union payloads distribute: `Promise<RpcStub<T> | null>` returns elide the stub arm.
+const maybeViaMethod = api.maybeStub()
+api.consumeMaybe(maybeViaMethod)
+
+// 8. map() over a declared `RpcStub<T>[]` return: the callback placeholder is `T`-shaped,
+// so pipelined calls on elements typecheck.
+const mapped = api.listStubs().map((c) => c.increment(2))
+expectAssignable<Promise<number[]>>(mapped)
+
+// 9. Self-referential stub returns compile (recursion in `Result` terminates).
+declare class Node extends RpcTarget {
+  next(): Promise<RpcStub<Node>>
+}
+declare const nodeStub: RpcStub<Node>
+const nextNode = nodeStub.next()
+expectType<RpcPromise<Node>>(nextNode)
+const grandchild = nextNode.next()
+expectType<RpcPromise<Node>>(grandchild)
+
+// 4 & 10. Awaited shapes: stubs nested in object results stay single stubs, and
+// plain-interface stubs keep their wrapper (awaiting still yields the stub itself).
+async function assertAwaitedShapes() {
+  const counter = await viaStub
+  expectType<RpcStub<Counter>>(counter)
+
+  const wrapped = await api.wrapped()
+  expectType<RpcStub<Counter>>(wrapped.s)
+  expectAssignable<Promise<number>>(wrapped.s.increment(1))
+
+  // Plain-interface stubs are not elided: this assignment is today's working behavior and
+  // must keep compiling (eliding would make the awaited value a stubified record).
+  const s: RpcStub<PlainApi> = await api.getApi()
+  expectAssignable<Promise<number>>(s.ping())
+  s.dup()
+
+  // `RpcStub<any>` results are not elided either: `[any] extends [Stubable]` is true, so
+  // without the IsAny guard these would collapse to `RpcPromise<unknown>` and await to
+  // `unknown`, losing the stub surface.
+  const anyFromMethod = await api.getAnyStub()
+  const anyFromProp = await api.anyStubProp
+  expectAssignable<Disposable>(anyFromMethod)
+  expectAssignable<Disposable>(anyFromProp)
+  anyFromMethod.dup()
+  anyFromProp.onRpcBroken((_error) => {})
+}
+
+void assertAwaitedShapes
+
+// @ts-expect-error pipelined methods keep their signatures — increment requires a number
+viaStub.increment("1")
+
+// @ts-expect-error methods not on Counter are not available on the elided promise
+viaStub.missing()

--- a/__type-tests__/stub-elision.test.ts
+++ b/__type-tests__/stub-elision.test.ts
@@ -39,11 +39,10 @@ interface ElisionApi {
   consumeMaybe(counter: RpcStub<Counter> | null): Promise<number>
 }
 
-// The brand-leak fix: a stub of a branded target no longer matches `Stubable` structurally
-// (the string-keyed brand is excluded from the stub's surface), which is the root cause of
-// double-stubification. Callable stubs remain `Stubable` — they are genuinely callable —
-// which is why `Stubify` checks `StubBase` before `Stubable`.
-type _BrandedStubIsNotStubable = Expect<Equal<RpcStub<Counter> extends Stubable ? true : false, false>>
+// Stubs keep the string-keyed brand on their surface (for workers-types interop), so they
+// match `Stubable` — harmless, because `Stubify`/`Result` check `StubBase` before `Stubable`.
+// That ordering is the actual double-stubification fix; it protects callable stubs too.
+type _BrandedStubIsStubable = Expect<Equal<RpcStub<Counter> extends Stubable ? true : false, true>>
 type _CallableStubIsStillStubable = Expect<Equal<RpcStub<Formatter> extends Stubable ? true : false, true>>
 
 declare const api: RpcStub<ElisionApi>

--- a/packages/capnweb-validate/src/internal/core.ts
+++ b/packages/capnweb-validate/src/internal/core.ts
@@ -98,12 +98,17 @@ type BaseType =
   | Response
   | Headers;
 
-type Stubify<T> = T extends Stubable
-  ? ValidatedStub<T>
-  : T extends Promise<infer U>
-    ? Stubify<U>
-    : T extends StubBase<unknown>
-      ? T
+// Arm ordering matters (mirrors the main package's `Stubify`):
+// - `Promise` before `StubBase`: promise-backed stubs match both and must resolve through the
+//   Promise arm.
+// - `StubBase` before `Stubable`: a stub of a callable `T` is itself callable, so it matches
+//   `Stubable`; checking `StubBase` first avoids double-wrapping existing stubs.
+type Stubify<T> = T extends Promise<infer U>
+  ? Stubify<U>
+  : T extends StubBase<unknown>
+    ? T
+    : T extends Stubable
+      ? ValidatedStub<T>
     : T extends Map<infer K, infer V>
       ? Map<Stubify<K>, Stubify<V>>
       : T extends Set<infer V>
@@ -157,10 +162,29 @@ type Unstubify<T> =
 type UnstubifyAll<T extends readonly unknown[]> = {
   [K in keyof T]: Unstubify<T[K]>;
 };
-type StubResult<T> = Promise<Stubify<T>> & ValidatedStub<T> & StubBase<T>;
+type IsAny<T> = 0 extends 1 & T ? true : false;
+type StubResultInner<T> = Promise<Stubify<T>> & ValidatedStub<T> & StubBase<T>;
+// Mirrors the main package's `Result` stub elision: a declared stub return/property collapses
+// to the same type as returning the payload directly — but only for `Stubable` payloads, since
+// only those await back to a stub. Distributes over unions, like the main package's `Result`,
+// so e.g. `ValidatedStub<T> | null` elides (this also makes `never` stay `never` instead of
+// matching the promise arm with `U = unknown`).
+// `any` needs explicit guards: `[any] extends [X]` is true for any `X`, so without them a
+// `Promise<any>` or `ValidatedStub<any>` return would recurse through the eliding arms and
+// collapse to `Promise<unknown> & StubBase<unknown>` instead of keeping the full stub surface.
+type StubResult<T> =
+  IsAny<T> extends true ? StubResultInner<T>
+  : T extends PromiseLike<unknown> & StubBase<infer U> ? StubResult<U>
+  : T extends StubBase<infer U>
+    ? (IsAny<U> extends true ? StubResultInner<T>
+       : [U] extends [Stubable] ? StubResult<U> : StubResultInner<T>)
+  : StubResultInner<T>;
 type StubMethodOrProperty<T> = T extends (...args: infer P) => infer R
   ? (...args: UnstubifyAll<P>) => StubResult<Awaited<R>>
   : StubResult<Awaited<T>>;
+// Deliberately repeats `StubMethodOrProperty`'s function arm instead of delegating to it:
+// the extra conditional layer of a delegation tips `ValidatedStub`'s recursive instantiation
+// over TypeScript's depth limit (TS2589).
 type MaybeCallableStub<T> = T extends (...args: infer P) => infer R
   ? (...args: UnstubifyAll<P>) => StubResult<Awaited<R>>
   : unknown;
@@ -196,9 +220,14 @@ type MapCallbackReturn<V> =
 export type ValidatedStub<T> = MaybeCallableStub<T> &
   (T extends object
     ? {
-        [K in Exclude<keyof T, symbol | keyof StubBase<never>>]: StubMethodOrProperty<
-          T[K]
-        >;
+        [K in Exclude<
+          keyof T,
+          | symbol
+          | "__RPC_TARGET_BRAND"
+          | "__WORKER_ENTRYPOINT_BRAND"
+          | "__DURABLE_OBJECT_BRAND"
+          | keyof StubBase<never>
+        >]: StubMethodOrProperty<T[K]>;
       } & {
         map<V>(callback: (value: MapCallbackValue<NonNullable<T>>) => MapCallbackReturn<V>): StubResult<
           Array<V>

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -272,13 +272,16 @@ type TupleProvider<T extends ReadonlyArray<unknown>> = {
 
 // Base type for all other types providing RPC-like interfaces.
 // Rewrites all methods/properties to be `MethodOrProperty`s, while preserving callable types.
+// `__RPC_TARGET_BRAND` deliberately flows through the key mapping (as a `never` property) so
+// stubs of branded targets stay assignable to workers-types' `Stubable`. Such stubs match our
+// `Stubable` too — harmless, since all machinery checks `StubBase` before `Stubable`.
 export type Provider<T> = MaybeCallableProvider<T> &
   (T extends ReadonlyArray<unknown>
     ? number extends T["length"] ? ArrayProvider<T[number]> : TupleProvider<T>
     : {
         [K in Exclude<
           keyof T,
-          symbol | typeof __RPC_TARGET_BRAND | keyof StubBase<never>
+          symbol | keyof StubBase<never>
         >]: MethodOrProperty<T[K]>;
       } & {
         map<V>(

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -21,7 +21,8 @@ export interface RpcTargetBranded {
 // `any` into inference.
 export type Stubable = RpcTargetBranded | ((...args: never[]) => unknown);
 
-type IsUnknown<T> = unknown extends T ? ([T] extends [unknown] ? true : false) : false;
+// Note: also true for `any` (call sites that care check `IsAny` first).
+type IsUnknown<T> = unknown extends T ? true : false;
 
 // Types that can be passed over RPC
 // The reason for using a generic type here is to build the serializable subset of RPC-compatible
@@ -95,11 +96,17 @@ type BaseType =
   | Response
   | Headers;
 // Recursively rewrite all `Stubable` types with `Stub`s, and resolve promises.
+// Arm ordering matters here:
+// - `Promise` must come before `StubBase`: `RpcPromise<T>` matches both, and must resolve
+//   through the Promise arm rather than pass through as-is.
+// - `StubBase` must come before `Stubable`: `Stub<T>` of a callable `T` is itself callable, so
+//   it matches `Stubable`. Checking `StubBase` first keeps existing stubs as-is instead of
+//   double-wrapping them as `Stub<Stub<T>>`.
 // prettier-ignore
 export type Stubify<T> =
-  T extends Stubable ? Stub<T>
-  : T extends Promise<infer U> ? Stubify<U>
+  T extends Promise<infer U> ? Stubify<U>
   : T extends StubBase<any> ? T
+  : T extends Stubable ? Stub<T>
   : T extends Map<infer K, infer V> ? Map<Stubify<K>, Stubify<V>>
   : T extends Set<infer V> ? Set<Stubify<V>>
   : T extends [] ? []
@@ -169,6 +176,19 @@ export type RpcPromise<T> =
   T extends Stubable ? Promise<Stub<T>> & Provider<T> & StubBase<T>
   : Promise<Stubify<T> & MaybeDisposable<T>> & Provider<T> & StubBase<T>;
 
+// The elision `Result` applies to a bare stub type: unwrap `Stub<T>` back to `T` when the
+// payload is `Stubable`. Such stubs await back to a stub either way, so eliding keeps a
+// declared `Promise<RpcStub<T>>` return interchangeable with a `Promise<T>` return.
+// Plain-interface stubs are NOT elided: `RpcPromise<U>` only awaits to `Stub<U>` when
+// `U extends Stubable`, so eliding those would change the awaited type from a stub to a
+// stubified record. The payload check is deliberately non-distributive (`[U] extends [...]`).
+// `Stub<any>` is not elided either: `[any] extends [Stubable]` is true, so without the `IsAny`
+// guard an `any`-payload stub would lose its stub surface.
+export type ElideStub<T> =
+  T extends StubBase<infer U>
+    ? (IsAny<U> extends true ? T : [U] extends [Stubable] ? U : T)
+    : T;
+
 // Type for method return or property on an RPC interface.
 // - Stubable types are replaced by stubs.
 // - RpcCompatible types are passed by value, with stubable types replaced by stubs
@@ -178,14 +198,20 @@ export type RpcPromise<T> =
 // Intersecting with `(Maybe)Provider` allows pipelining.
 // prettier-ignore
 type Result<R> =
-  IsAny<R> extends true ? UnknownResult
-  : IsUnknown<R> extends true ? UnknownResult
-  : R extends Stubable ? RpcPromise<R>
+  IsAny<R> extends true ? RpcPromise<unknown>
+  // `RpcPromise<U>`: always safe to normalize — `Result` is idempotent — so a declared
+  // `RpcPromise<U>` return produces the same type as a `Promise<U>` return.
+  : R extends PromiseLike<unknown> & StubBase<infer U> ? Result<U>
+  // Bare stubs: elide per `ElideStub` above. Note there is no `RpcCompatible<R>` re-check
+  // here: anything matching our `StubBase` was produced by machinery that already enforced
+  // the constraint, and re-evaluating `RpcCompatible<R>` in this arm recurses through its
+  // `Stub<Stubable>` member back into `Result`, tripping TS2615 circularity errors in mapped
+  // types.
+  : R extends StubBase<any> ? RpcPromise<ElideStub<R>>
   : R extends RpcCompatible<R> ? RpcPromise<R>
   : never;
 
 type IsAny<T> = 0 extends (1 & T) ? true : false;
-type UnknownResult = Promise<unknown> & Provider<unknown> & StubBase<unknown>;
 
 // Type for method or property on an RPC interface.
 // For methods, unwrap `Stub`s in parameters, and rewrite returns to be `Result`s.
@@ -193,7 +219,7 @@ type UnknownResult = Promise<unknown> & Provider<unknown> & StubBase<unknown>;
 // For properties, rewrite types to be `Result`s.
 // In each case, unwrap `Promise`s.
 type MethodOrProperty<V> = V extends (...args: infer P) => infer R
-  ? (...args: UnstubifyAll<P>) => IsAny<R> extends true ? UnknownResult : Result<Awaited<R>>
+  ? (...args: UnstubifyAll<P>) => Result<Awaited<R>>
   : Result<Awaited<V>>;
 
 // Type for the callable part of an `Provider` if `T` is callable.
@@ -252,7 +278,7 @@ export type Provider<T> = MaybeCallableProvider<T> &
     : {
         [K in Exclude<
           keyof T,
-          symbol | keyof StubBase<never>
+          symbol | typeof __RPC_TARGET_BRAND | keyof StubBase<never>
         >]: MethodOrProperty<T[K]>;
       } & {
         map<V>(


### PR DESCRIPTION
Presently declaring an RPC method to return `Promise<RpcStub<T>>` gave you a broken type: an internal brand property made the type machinery treat the already-stubbed result as something that still needed wrapping, so awaiting yielded `RpcStub<RpcStub<T>>` (TS2322) and passing the result into another RPC call failed to compile (TS2345), even though the runtime behaved correctly. 

Now the type machinery recognizes existing stubs before re-wrapping, so a `Promise<RpcStub<T>>` return types identically to a `Promise<T>` return and awaits, pipelined calls, and .map() over stub arrays all compile.

Nothing changes at runtime; the one migration is rewriting any explicit `RpcPromise<RpcStub<T>>` annotation as `RpcPromise<T>`.