### PR TITLE
Publish workspace packages in prereleases and pkg-pr-new

### DIFF
--- a/.github/version-script.ts
+++ b/.github/version-script.ts
@@ -1,15 +1,34 @@
 import * as fs from "node:fs";
+import * as path from "node:path";
 import { execSync } from "node:child_process";
+
 async function main() {
   try {
     console.log("Getting current git hash...");
-    const stdout = execSync("git rev-parse --short HEAD").toString();
-    console.log("Git hash:", stdout.trim());
+    const stdout = execSync("git rev-parse --short HEAD").toString().trim();
+    console.log("Git hash:", stdout);
 
-    const path = "./package.json";
-    const packageJson = JSON.parse(fs.readFileSync(path, "utf-8"));
-    packageJson.version = `0.0.0-${stdout.trim()}`;
-    fs.writeFileSync(path, `${JSON.stringify(packageJson, null, 2)}\n`);
+    const version = `0.0.0-${stdout}`;
+    const packageFiles = ["./package.json"];
+
+    const packagesDir = "./packages";
+    if (fs.existsSync(packagesDir)) {
+      for (const entry of fs.readdirSync(packagesDir, { withFileTypes: true })) {
+        if (entry.isDirectory()) {
+          const pkgPath = path.join(packagesDir, entry.name, "package.json");
+          if (fs.existsSync(pkgPath)) {
+            packageFiles.push(pkgPath);
+          }
+        }
+      }
+    }
+
+    for (const pkgPath of packageFiles) {
+      const packageJson = JSON.parse(fs.readFileSync(pkgPath, "utf-8"));
+      packageJson.version = version;
+      fs.writeFileSync(pkgPath, `${JSON.stringify(packageJson, null, 2)}\n`);
+      console.log(`Updated ${pkgPath} to ${version}`);
+    }
   } catch (error) {
     console.error(error);
     process.exit(1);

--- a/.github/workflows/pkg-pr-new.yml
+++ b/.github/workflows/pkg-pr-new.yml
@@ -24,4 +24,4 @@ jobs:
         run: npm run build
 
       - name: Publish to pkg.pr.new
-        run: npx pkg-pr-new publish
+        run: npx pkg-pr-new publish . ./packages/*

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -82,8 +82,9 @@ jobs:
           cache: "npm"
 
       - run: npm ci
+      - run: npm run build
 
       - name: Modify package.json version
         run: npx tsx .github/version-script.ts
 
-      - run: npm publish --tag beta
+      - run: npm publish --workspaces --include-workspace-root --tag beta


### PR DESCRIPTION
### Problem

Prereleases on `main` and PR previews via `pkg-pr-new` only publish the root `capnweb` package. Downstream consumers testing prereleases cannot resolve pre-release builds of `capnweb-validate`.

### Solution

1. Pass workspace glob `./packages/*` to `pkg-pr-new publish`.
2. Update `version-script.ts` to rewrite versions across `./package.json` and `packages/*/package.json`.
3. Build and publish all workspaces in `release.yml` with `npm publish --workspaces --include-workspace-root --tag beta`.

Before:
```bash
# Only capnweb published
npx pkg-pr-new publish
npm publish --tag beta
```

After:
```bash
# Both capnweb and capnweb-validate published
npx pkg-pr-new publish . ./packages/*
npm publish --workspaces --include-workspace-root --tag beta
```