### PR TITLE
chore: enhance type to keep reference to its `T`

### DIFF
--- a/packages/capnweb-validate/src/internal/core.ts
+++ b/packages/capnweb-validate/src/internal/core.ts
@@ -219,16 +219,17 @@ type MapCallbackReturn<V> =
   InvalidNativePromiseInMapResult<V> extends never ? V : never;
 export type ValidatedStub<T> = MaybeCallableStub<T> &
   (T extends object
-    ? {
-        [K in Exclude<
+    ? Pick<
+        { [K in keyof T]: StubMethodOrProperty<T[K]> },
+        Exclude<
           keyof T,
           | symbol
           | "__RPC_TARGET_BRAND"
           | "__WORKER_ENTRYPOINT_BRAND"
           | "__DURABLE_OBJECT_BRAND"
           | keyof StubBase<never>
-        >]: StubMethodOrProperty<T[K]>;
-      } & {
+        >
+      > & {
         map<V>(callback: (value: MapCallbackValue<NonNullable<T>>) => MapCallbackReturn<V>): StubResult<
           Array<V>
         >;

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -288,12 +288,10 @@ type TupleProvider<T extends ReadonlyArray<unknown>> = {
 export type Provider<T> = MaybeCallableProvider<T> &
   (T extends ReadonlyArray<unknown>
     ? number extends T["length"] ? ArrayProvider<T[number]> : TupleProvider<T>
-    : {
-        [K in Exclude<
-          keyof T,
-          symbol | keyof StubBase<never>
-        >]: MethodOrProperty<T[K]>;
-      } & {
+    : Pick<
+        { [K in keyof T]: MethodOrProperty<T[K]> },
+        Exclude<keyof T, symbol | keyof StubBase<never>>
+      > & {
         map<V>(
           callback: (value: MapCallbackValue<NonNullable<T>>) => MapCallbackReturn<V>
         ): Result<Array<V>>;


### PR DESCRIPTION
Closes #258 

When creating a stub type from a server class `T`, it drop keys such as brand symbols. Currently it iterates with `Exclude<keyof T, …>`, which makes TypeScript then treats the result as a new object, so "Go to Definition" on `api.authenticate()` no longer jumps to `T.authenticate`. This PR still drops the same keys, but maps over `keyof T` first and then `Pick`.

Here is a minimal PoC difference between using `Exclude<keyof T, …>` vs using `Pick`:

https://www.typescriptlang.org/play/?#code/MYGwhgzhAEDKYFsAOICm0DeAoa0BmA9gQBQCUmOu0ATqgC4Cu1AdtHdQ6gNyUC+lAIzDUyFKjXpNW7Tj1z9+WOgE8k6AIIAeACoA+aAF4x0ANoBpaAEtWAUQAeoBgBNUmgNaplBPNG0AaaAByIWpA3QBdAC5fc3CeXh4lVXQAIR19IwAFS2A3TUpscXMrVg8vH20omLM4vj9Ke0cXd09vXwDg4TCsXUSXUGF0YAJmCDpoMGiteGQ0Xqx+8FpoYdHxgWi0mZRUeawwADpCElIeAHoz6AA9AH4sASOiMnPL26wsIA


https://github.com/user-attachments/assets/238e27a4-b262-4fcf-83ec-9c8f80d79fea
