### PR TITLE
ci: enable docs preview domain

### DIFF
--- a/packages/docs/wrangler.jsonc
+++ b/packages/docs/wrangler.jsonc
@@ -17,6 +17,7 @@
 		{
 			"pattern": "pr.capnweb.com",
 			"custom_domain": true,
+			"enabled": false,
 			"previews_enabled": true
 		}
 	],

--- a/packages/docs/wrangler.jsonc
+++ b/packages/docs/wrangler.jsonc
@@ -12,7 +12,14 @@
 	// The site is the apex domain and nothing else. `custom_domain` makes Cloudflare
 	// own the DNS record and the certificate for it, so the record cannot drift away
 	// from the Worker by hand.
-	"routes": [{ "pattern": "capnweb.com", "custom_domain": true }],
+	"routes": [
+		{ "pattern": "capnweb.com", "custom_domain": true },
+		{
+			"pattern": "pr.capnweb.com",
+			"custom_domain": true,
+			"previews_enabled": true
+		}
+	],
 
 	// No `*.workers.dev` copy. Canonical URLs, the sitemap and the links inside
 	// `/llms.txt` all name `https://capnweb.com` (see `site` in astro.config.ts), and a


### PR DESCRIPTION
## Summary
- keep `capnweb.com` as the production custom domain
- add `pr.capnweb.com` as a preview-enabled custom domain route
- keep bare `pr.capnweb.com` disabled while allowing preview URLs like `https://<preview-name>.pr.capnweb.com`

## Verification
- tested the same config shape on a disposable Worker using `testpr.yomnashousha.com` and `pr.testpr.yomnashousha.com`
- `npx wrangler deploy` reported `pr.testpr.yomnashousha.com (custom domain) [disabled, previews: enabled]`
- `npx wrangler preview --name smoke2` returned `preview_urls: ["https://smoke2.pr.testpr.yomnashousha.com"]`

## Follow-up
This must be applied by `npx wrangler deploy -c packages/docs/wrangler.jsonc`; `wrangler preview` does not create/update custom domain routes. The existing `Deploy Docs` workflow runs that command on `main`, so this should be provisioned after merge when the docs deploy runs.