### PR TITLE
Don't cite a released import id after the reference has settled

### DIFF
--- a/.changeset/settled-import-guard.md
+++ b/.changeset/settled-import-guard.md
@@ -1,0 +1,14 @@
+---
+"capnweb": patch
+---
+
+Don't cite a released import id after the reference has settled.
+
+`ImportTableEntry.resolve()` stores the resolution and immediately calls `sendRelease()`, so the
+import is dead on both sides — but the entry keeps `importId`, since the release accounting names
+the id through it. `getImport()` still returned that id, so passing a settled `RpcPromise` back as
+an argument re-serialized a released id. The peer could not find it and threw inside `readLoop`,
+which is wrapped in a single session-wide `.catch(err => this.abort(err))` — so a call-level fault
+destroyed the whole session. `getImport()` now declines a settled entry and the caller exports a
+fresh stub instead, matching `dispose()`, `abort()` and `onBroken()`, which already branch on
+`resolution`.

--- a/__tests__/index.test.ts
+++ b/__tests__/index.test.ts
@@ -4227,3 +4227,44 @@ describe("deserialization and transport correctness", () => {
     expect(sentReason).toBe("a".repeat(MAX_CLOSE_REASON_BYTES - 1));
   });
 });
+
+describe("settled import references", () => {
+  // Regression: ImportTableEntry.resolve() stores `resolution` and immediately calls
+  // sendRelease(), so the import id is dead on both sides -- but the entry keeps `importId`,
+  // because the release accounting names the id through it. getImport() then still handed out
+  // that dead id, so passing the settled promise object into a later message re-serialized a
+  // released id. The peer could not find it and threw inside readLoop, and because readLoop is
+  // wrapped in a single session-wide `.catch(err => this.abort(err))`, a call-level fault
+  // destroyed the entire session.
+  //
+  // dispose(), abort() and onBroken() all already branch on `resolution`; getImport() did not.
+  it("does not cite a released import id after the reference has settled", async () => {
+    let harness = new TestHarness(new TestTarget());
+
+    // Awaiting settles the entry: the resolution is stored and the import is released.
+    let promise = harness.stub.returnNumber(7);
+    await promise;
+
+    // Passing the same *promise object* (not its awaited value) as an argument is what
+    // re-serialized the now-dead id.
+    expect(await harness.stub.square(promise)).toBe(49);
+
+    // The load-bearing assertion: a failing call would be tolerable, a dead session is not.
+    expect(await harness.stub.returnNumber(3)).toBe(3);
+
+    harness.stub.dispose();
+  });
+
+  // A guard that cleared `importId` instead of gating its use would stop the release
+  // accounting naming the id, leaking the peer's exports.
+  it("still releases settled imports by id", async () => {
+    let harness = new TestHarness(new TestTarget());
+
+    await harness.stub.returnNumber(1);
+    await harness.stub.returnNumber(2);
+
+    expect(await harness.stub.returnNumber(3)).toBe(3);
+
+    harness.stub.dispose();
+  });
+});

--- a/src/rpc.ts
+++ b/src/rpc.ts
@@ -247,6 +247,11 @@ class ImportTableEntry {
   }
 
   async awaitResolution(): Promise<RpcPayload> {
+    // If the entry has already settled, the import has been released (resolve() calls
+    // sendRelease()), so there is nothing left on the wire to pull. Read the stored
+    // resolution instead of sending a "pull" naming a released id.
+    if (this.resolution) return this.resolution.pull();
+
     if (!this.activePull) {
       this.session.sendPull(this.importId);
       this.activePull = Promise.withResolvers<void>();
@@ -662,7 +667,11 @@ class RpcSessionImpl implements Importer, Exporter {
   }
 
   getImport(hook: StubHook): ImportId | undefined {
-    if (hook instanceof RpcImportHook && hook.entry && hook.entry.session === this) {
+    // A settled entry has already released its import (resolve() calls sendRelease()), so its
+    // importId no longer names anything on the peer. Fall through to exporting the resolution,
+    // the way dispose(), abort() and onBroken() all branch on `resolution`.
+    if (hook instanceof RpcImportHook && hook.entry && hook.entry.session === this &&
+        !hook.entry.resolution) {
       return hook.entry.importId;
     } else {
       return undefined;


### PR DESCRIPTION
Fixes #265.

### The problem

`ImportTableEntry.resolve()` stores the resolution and immediately calls `sendRelease()`, so the import is dead on both sides. The entry keeps `importId` — it has to, because the release accounting names the id through it — but `getImport()` still returned that id unconditionally.

So passing a settled `RpcPromise` back as an argument re-serialized a released id. The peer cannot find it and throws inside `readLoop`. Since `readLoop` is wrapped in a single session-wide `.catch(err => this.abort(err))`, a call-level fault tears down the **whole session**, not just the offending call.

We hit this in production on a connection that multiplexes every service in an Electron desktop app: one stale reference took the entire connection down and the user got a "connection lost" screen.

### The fix

`getImport()` declines a settled entry, so the caller exports a fresh stub instead. This is the same test `dispose()`, `abort()` and `onBroken()` already apply — they all branch on `resolution`; `getImport()` was the one that did not.

The guard gates the *use* of `importId` rather than clearing it, so release accounting is unchanged. A test covers that specifically, because a guard that cleared the id would still emit a release frame — just one naming `null` — and silently leak the peer's exports.

`awaitResolution()` gets the same guard. It is **not reachable** with a settled entry today: `RpcImportHook.pull()` returns on `entry.resolution` one line earlier, and `sendStream` seeds `activePull` via `pulling = true`, so the `sendPull` branch never runs. It is defensive only — included so a future caller cannot regress into a `pull` naming a released id. Happy to drop it if you would rather not carry an unreachable branch.

### Tests

Two tests in `__tests__/index.test.ts`. The first is load-bearing — verified to **fail on unpatched `main`** with `no such entry on exports table`, and to pass with the fix. The second guards against the clear-the-id mis-fix described above.

Full suite on this branch:

| suite | result |
|---|---|
| `vitest run --project=node` | 407 / 407 pass |
| `vitest run --project=workerd` | 210 / 210 pass |
| `npm run test:types` | pass |

I did not run the browser projects or `test:bun` locally (Playwright download blocked behind a corporate proxy); neither covers this path, but CI will.

### Scope note

There is a second, separate defect where the settled resolution is a **non-promise stub** — the library then cannot pull it and the call fails with `Tried to resolve a non-promise stub`. That is unchanged by this PR and is out of scope here; this change only stops that case from being *session*-fatal rather than call-level. Reported separately in #266, which is about `readLoop`'s missing per-frame error boundary.

Present in 0.10.0 and still in 0.12.0, so upgrading is not a workaround — we are currently carrying this as a local patch against the published bundle, which is what prompted the report.
